### PR TITLE
Change ticker events to use normal DOM events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.0] - unreleased
 
-- ticking
-- DOM event calbacks (e.detail.dt!)
-- ontick etc. rename?
-- DOM lifecycle hooks
+- **New:** Elements now emit `connected`, `ready` and `disconnected` lifecycle events that bubble up the DOM tree.
+- **Breaking Change:** 💥 Completely revamped the ticker system to make it easier to use, and make three-elements more straight-forward to integrate with web application frameworks:
+  - Ticker callbacks have been renamed from `onupdate`, `onlateupdate`, `onframe` and `onrender` to `ontick`, `onlatetick`, `onframewtick` and `onrendertick`.
+  - Ticker events now are normal CustomEvents, meaning that you would implement callbacks like any other DOM event callback, eg. `ontick="(e) => console.log(e)"`.
+  - You can also directly subscribe to these events through `element.addEventListener`, but in this case you may need to explicitly set the element's `ticking` attribute/property to true in order for it to actually connect to the game's ticker.
+  - Ticker events have an `event.detail.deltaTime` property that stores the delta time, but you can also get it directly from the game object via `element.game.deltaTime`.
 
 ## [0.1.3] - 2021-01-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - ticking
 - DOM event calbacks (e.detail.dt!)
-- onupdate etc. rename?
+- ontick etc. rename?
 - DOM lifecycle hooks
 
 ## [0.1.3] - 2021-01-13
 
-- **Fixed:** compatibility with frameworks that set `onupdate` & friends directly as properties (eg. Svelte)
+- **Fixed:** compatibility with frameworks that set `ontick` & friends directly as properties (eg. Svelte)
 
 ## [0.1.2] - 2021-01-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - unreleased
+
+- ticking
+- DOM event calbacks (e.detail.dt!)
+- DOM lifecycle hooks
+
 ## [0.1.3] - 2021-01-13
 
 - **Fixed:** compatibility with frameworks that set `onupdate` & friends directly as properties (eg. Svelte)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - ticking
 - DOM event calbacks (e.detail.dt!)
+- onupdate etc. rename?
 - DOM lifecycle hooks
 
 ## [0.1.3] - 2021-01-13

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
     <three-directional-light intensity="0.8" position="10, 10, 50"></three-directional-light>
 
     <!-- Spinning dodecahedron! -->
-    <three-mesh onupdate="dt => this.rotation.z += dt">
+    <three-mesh ontick="dt => this.rotation.z += dt">
       <three-dodecahedron-buffer-geometry></three-dodecahedron-buffer-geometry>
       <three-mesh-standard-material color="red"></three-mesh-standard-material>
     </three-mesh>
@@ -119,7 +119,7 @@ Now for a little fun experiment: open your browser's devtools, inspect your DOM,
 ```html
 <three-game>
   <three-scene>
-    <three-mesh onupdate="console.log">
+    <three-mesh ontick="console.log">
       <three-box-geometry></three-box-geometry>
       <three-mesh-normal-material></three-mesh-normal-material>
     </three-mesh>
@@ -127,13 +127,13 @@ Now for a little fun experiment: open your browser's devtools, inspect your DOM,
 </three-game>
 ```
 
-`onupdate` is expected to return a function that takes a single argument -- more on that below. In this small example, we will simply log it to the browser console. Let's do something a little more involved:
+`ontick` is expected to return a function that takes a single argument -- more on that below. In this small example, we will simply log it to the browser console. Let's do something a little more involved:
 
 ```html
 <three-game>
   <three-scene>
     <three-mesh
-      onupdate="dt => this.setAttribute('rotation-z', parseFloat(this.getAttribute('rotation-z')) + 3 * dt)"
+      ontick="dt => this.setAttribute('rotation-z', parseFloat(this.getAttribute('rotation-z')) + 3 * dt)"
     >
       <three-box-geometry></three-box-geometry>
       <three-mesh-normal-material></three-mesh-normal-material>
@@ -149,7 +149,7 @@ The argument passed into the callback function -- `dt` -- is a delta time value 
 ```html
 <three-game autorender>
   <three-scene>
-    <three-mesh onupdate="dt => this.object.rotation.z += 3 * dt">
+    <three-mesh ontick="dt => this.object.rotation.z += 3 * dt">
       <three-box-geometry></three-box-geometry>
       <three-mesh-normal-material></three-mesh-normal-material>
     </three-mesh>

--- a/examples/animations.html
+++ b/examples/animations.html
@@ -6,7 +6,7 @@
   </head>
   <body>
     <!-- Here's a simple Three.js scene. -->
-    <three-game>
+    <three-game id="game">
       <three-scene background-color="#222">
         <!-- Lights on! -->
         <three-ambient-light intensity="0.2"></three-ambient-light>
@@ -33,11 +33,11 @@
         let colorAnimation
         let speedAnimation
 
-        thingy.ontick = ({ detail: { dt } }) => {
+        thingy.ontick = () => {
           if (rotateSpeed > 0) {
-            thingy.object.rotateX(rotateSpeed * 0.8 * dt)
-            thingy.object.rotateY(rotateSpeed * 0.4 * dt)
-            thingy.object.rotateZ(rotateSpeed * dt)
+            thingy.object.rotateX(rotateSpeed * 0.8 * game.deltaTime)
+            thingy.object.rotateY(rotateSpeed * 0.4 * game.deltaTime)
+            thingy.object.rotateZ(rotateSpeed * game.deltaTime)
             thingy.game.requestFrame()
           }
         }

--- a/examples/animations.html
+++ b/examples/animations.html
@@ -33,7 +33,7 @@
         let colorAnimation
         let speedAnimation
 
-        thingy.onupdate = ({ detail: { dt } }) => {
+        thingy.ontick = ({ detail: { dt } }) => {
           if (rotateSpeed > 0) {
             thingy.object.rotateX(rotateSpeed * 0.8 * dt)
             thingy.object.rotateY(rotateSpeed * 0.4 * dt)

--- a/examples/animations.html
+++ b/examples/animations.html
@@ -33,7 +33,7 @@
         let colorAnimation
         let speedAnimation
 
-        thingy.onupdate = (dt) => {
+        thingy.onupdate = ({ detail: { dt } }) => {
           if (rotateSpeed > 0) {
             thingy.object.rotateX(rotateSpeed * 0.8 * dt)
             thingy.object.rotateY(rotateSpeed * 0.4 * dt)

--- a/examples/components.html
+++ b/examples/components.html
@@ -33,7 +33,7 @@
             this.appendChild(geometry)
             this.appendChild(material)
 
-            this.onupdate = ({ detail: { dt } }) => {
+            this.ontick = ({ detail: { dt } }) => {
               this.object.rotation.x = 1.4 * (this.object.rotation.y += this.speed * dt)
 
               /* Make sure a frame is queued the next tick */

--- a/examples/components.html
+++ b/examples/components.html
@@ -33,8 +33,8 @@
             this.appendChild(geometry)
             this.appendChild(material)
 
-            this.ontick = ({ detail: { dt } }) => {
-              this.object.rotation.x = 1.4 * (this.object.rotation.y += this.speed * dt)
+            this.ontick = () => {
+              this.object.rotation.x = 1.4 * (this.object.rotation.y += this.speed * game.deltaTime)
 
               /* Make sure a frame is queued the next tick */
               this.game.requestFrame()

--- a/examples/components.html
+++ b/examples/components.html
@@ -33,7 +33,7 @@
             this.appendChild(geometry)
             this.appendChild(material)
 
-            this.onupdate = (dt) => {
+            this.onupdate = ({ detail: { dt } }) => {
               this.object.rotation.x = 1.4 * (this.object.rotation.y += this.speed * dt)
 
               /* Make sure a frame is queued the next tick */

--- a/examples/gltf.html
+++ b/examples/gltf.html
@@ -23,7 +23,10 @@
         <three-directional-light intensity="0.8" position="10, 10, 50"></three-directional-light>
 
         <!-- Let's have a mesh that only rotates when a frame is being rendered. -->
-        <three-mesh position-y="6" onframetick="e => this.object.rotation.z += 10 * e.detail.dt">
+        <three-mesh
+          position-y="6"
+          onframetick="({target}) => target.object.rotation.z += 10 * target.game.deltaTime"
+        >
           <three-dodecahedron-buffer-geometry></three-dodecahedron-buffer-geometry>
           <three-mesh-standard-material color="red"></three-mesh-standard-material>
         </three-mesh>

--- a/examples/gltf.html
+++ b/examples/gltf.html
@@ -23,7 +23,7 @@
         <three-directional-light intensity="0.8" position="10, 10, 50"></three-directional-light>
 
         <!-- Let's have a mesh that only rotates when a frame is being rendered. -->
-        <three-mesh position-y="6" onframe="dt => this.object.rotation.z += 10 * dt">
+        <three-mesh position-y="6" onframe="e => this.object.rotation.z += 10 * e.detail.dt">
           <three-dodecahedron-buffer-geometry></three-dodecahedron-buffer-geometry>
           <three-mesh-standard-material color="red"></three-mesh-standard-material>
         </three-mesh>

--- a/examples/gltf.html
+++ b/examples/gltf.html
@@ -23,7 +23,7 @@
         <three-directional-light intensity="0.8" position="10, 10, 50"></three-directional-light>
 
         <!-- Let's have a mesh that only rotates when a frame is being rendered. -->
-        <three-mesh position-y="6" onframe="e => this.object.rotation.z += 10 * e.detail.dt">
+        <three-mesh position-y="6" onframetick="e => this.object.rotation.z += 10 * e.detail.dt">
           <three-dodecahedron-buffer-geometry></three-dodecahedron-buffer-geometry>
           <three-mesh-standard-material color="red"></three-mesh-standard-material>
         </three-mesh>

--- a/examples/static.html
+++ b/examples/static.html
@@ -7,7 +7,7 @@
   <body>
     <!-- Here's a simple Three.js scene. Note that we're setting the "autorender" attribute
     to make sure that a frame is rendered every tick. -->
-    <three-game autorender>
+    <three-game autorender id="game">
       <three-scene background-color="#ffe">
         <!-- Lights -->
         <three-ambient-light intensity="0.2"></three-ambient-light>
@@ -15,7 +15,7 @@
 
         <!-- Scene Contents -->
         <three-group
-          ontick="({ detail: { dt }}) => this.object.rotation.x = this.object.rotation.y += 1 * dt"
+          ontick="() => this.object.rotation.x = this.object.rotation.y += 1 * game.deltaTime"
         >
           <three-mesh scale="2.5">
             <three-dodecahedron-buffer-geometry></three-dodecahedron-buffer-geometry>
@@ -23,11 +23,11 @@
           </three-mesh>
 
           <three-group
-            ontick="({ detail: { dt }}) => this.object.rotation.x = this.object.rotation.y += 0.5 * dt"
+            ontick="() => this.object.rotation.x = this.object.rotation.y += 0.5 * game.deltaTime"
           >
             <three-mesh
               position="-4, 0, 0"
-              ontick="({ detail: { dt }}) => this.object.rotation.x = this.object.rotation.z += 1 * dt"
+              ontick="() => this.object.rotation.x = this.object.rotation.z += 1 * game.deltaTime"
             >
               <three-dodecahedron-buffer-geometry></three-dodecahedron-buffer-geometry>
               <three-mesh-standard-material color="red"></three-mesh-standard-material>
@@ -35,11 +35,11 @@
           </three-group>
 
           <three-group
-            ontick="({ detail: { dt }}) => this.object.rotation.x = this.object.rotation.z += 1.5 * dt"
+            ontick="() => this.object.rotation.x = this.object.rotation.z += 1.5 * game.deltaTime"
           >
             <three-mesh
               position="4, 0, 0"
-              ontick="({ detail: { dt }}) => this.object.rotation.x = this.object.rotation.z += 1 * dt"
+              ontick="() => this.object.rotation.x = this.object.rotation.z += 1 * game.deltaTime"
             >
               <three-dodecahedron-buffer-geometry></three-dodecahedron-buffer-geometry>
               <three-mesh-standard-material color="yellow"></three-mesh-standard-material>
@@ -47,11 +47,11 @@
           </three-group>
 
           <three-group
-            ontick="({ detail: { dt }}) => this.object.rotation.x = this.object.rotation.y += 2 * dt"
+            ontick="() => this.object.rotation.x = this.object.rotation.y += 2 * game.deltaTime"
           >
             <three-mesh
               position="0, 4, 0"
-              ontick="({ detail: { dt }}) => this.object.rotation.x = this.object.rotation.z += 1 * dt"
+              ontick="() => this.object.rotation.x = this.object.rotation.z += 1 * game.deltaTime"
             >
               <three-dodecahedron-buffer-geometry></three-dodecahedron-buffer-geometry>
               <three-mesh-standard-material color="green"></three-mesh-standard-material>
@@ -59,11 +59,11 @@
           </three-group>
 
           <three-group
-            ontick="({ detail: { dt }}) => this.object.rotation.x = this.object.rotation.z += 2.5 * dt"
+            ontick="() => this.object.rotation.x = this.object.rotation.z += 2.5 * game.deltaTime"
           >
             <three-mesh
               position="0, -4, 0"
-              ontick="({ detail: { dt }}) => this.object.rotation.x = this.object.rotation.z += 1 * dt"
+              ontick="() => this.object.rotation.x = this.object.rotation.z += 1 * game.deltaTime"
             >
               <three-dodecahedron-buffer-geometry></three-dodecahedron-buffer-geometry>
               <three-mesh-standard-material color="blue"></three-mesh-standard-material>

--- a/examples/static.html
+++ b/examples/static.html
@@ -15,7 +15,7 @@
 
         <!-- Scene Contents -->
         <three-group
-          onupdate="({ detail: { dt }}) => this.object.rotation.x = this.object.rotation.y += 1 * dt"
+          ontick="({ detail: { dt }}) => this.object.rotation.x = this.object.rotation.y += 1 * dt"
         >
           <three-mesh scale="2.5">
             <three-dodecahedron-buffer-geometry></three-dodecahedron-buffer-geometry>
@@ -23,11 +23,11 @@
           </three-mesh>
 
           <three-group
-            onupdate="({ detail: { dt }}) => this.object.rotation.x = this.object.rotation.y += 0.5 * dt"
+            ontick="({ detail: { dt }}) => this.object.rotation.x = this.object.rotation.y += 0.5 * dt"
           >
             <three-mesh
               position="-4, 0, 0"
-              onupdate="({ detail: { dt }}) => this.object.rotation.x = this.object.rotation.z += 1 * dt"
+              ontick="({ detail: { dt }}) => this.object.rotation.x = this.object.rotation.z += 1 * dt"
             >
               <three-dodecahedron-buffer-geometry></three-dodecahedron-buffer-geometry>
               <three-mesh-standard-material color="red"></three-mesh-standard-material>
@@ -35,11 +35,11 @@
           </three-group>
 
           <three-group
-            onupdate="({ detail: { dt }}) => this.object.rotation.x = this.object.rotation.z += 1.5 * dt"
+            ontick="({ detail: { dt }}) => this.object.rotation.x = this.object.rotation.z += 1.5 * dt"
           >
             <three-mesh
               position="4, 0, 0"
-              onupdate="({ detail: { dt }}) => this.object.rotation.x = this.object.rotation.z += 1 * dt"
+              ontick="({ detail: { dt }}) => this.object.rotation.x = this.object.rotation.z += 1 * dt"
             >
               <three-dodecahedron-buffer-geometry></three-dodecahedron-buffer-geometry>
               <three-mesh-standard-material color="yellow"></three-mesh-standard-material>
@@ -47,11 +47,11 @@
           </three-group>
 
           <three-group
-            onupdate="({ detail: { dt }}) => this.object.rotation.x = this.object.rotation.y += 2 * dt"
+            ontick="({ detail: { dt }}) => this.object.rotation.x = this.object.rotation.y += 2 * dt"
           >
             <three-mesh
               position="0, 4, 0"
-              onupdate="({ detail: { dt }}) => this.object.rotation.x = this.object.rotation.z += 1 * dt"
+              ontick="({ detail: { dt }}) => this.object.rotation.x = this.object.rotation.z += 1 * dt"
             >
               <three-dodecahedron-buffer-geometry></three-dodecahedron-buffer-geometry>
               <three-mesh-standard-material color="green"></three-mesh-standard-material>
@@ -59,11 +59,11 @@
           </three-group>
 
           <three-group
-            onupdate="({ detail: { dt }}) => this.object.rotation.x = this.object.rotation.z += 2.5 * dt"
+            ontick="({ detail: { dt }}) => this.object.rotation.x = this.object.rotation.z += 2.5 * dt"
           >
             <three-mesh
               position="0, -4, 0"
-              onupdate="({ detail: { dt }}) => this.object.rotation.x = this.object.rotation.z += 1 * dt"
+              ontick="({ detail: { dt }}) => this.object.rotation.x = this.object.rotation.z += 1 * dt"
             >
               <three-dodecahedron-buffer-geometry></three-dodecahedron-buffer-geometry>
               <three-mesh-standard-material color="blue"></three-mesh-standard-material>

--- a/examples/static.html
+++ b/examples/static.html
@@ -14,46 +14,56 @@
         <three-directional-light intensity="0.8" position="10, 10, 50"></three-directional-light>
 
         <!-- Scene Contents -->
-        <three-group onupdate="dt => this.object.rotation.x = this.object.rotation.y += 1 * dt">
+        <three-group
+          onupdate="({ detail: { dt }}) => this.object.rotation.x = this.object.rotation.y += 1 * dt"
+        >
           <three-mesh scale="2.5">
             <three-dodecahedron-buffer-geometry></three-dodecahedron-buffer-geometry>
             <three-mesh-standard-material color="hotpink"></three-mesh-standard-material>
           </three-mesh>
 
-          <three-group onupdate="dt => this.object.rotation.x = this.object.rotation.y += 0.5 * dt">
+          <three-group
+            onupdate="({ detail: { dt }}) => this.object.rotation.x = this.object.rotation.y += 0.5 * dt"
+          >
             <three-mesh
               position="-4, 0, 0"
-              onupdate="dt => this.object.rotation.x = this.object.rotation.z += 1 * dt"
+              onupdate="({ detail: { dt }}) => this.object.rotation.x = this.object.rotation.z += 1 * dt"
             >
               <three-dodecahedron-buffer-geometry></three-dodecahedron-buffer-geometry>
               <three-mesh-standard-material color="red"></three-mesh-standard-material>
             </three-mesh>
           </three-group>
 
-          <three-group onupdate="dt => this.object.rotation.x = this.object.rotation.z += 1.5 * dt">
+          <three-group
+            onupdate="({ detail: { dt }}) => this.object.rotation.x = this.object.rotation.z += 1.5 * dt"
+          >
             <three-mesh
               position="4, 0, 0"
-              onupdate="dt => this.object.rotation.x = this.object.rotation.z += 1 * dt"
+              onupdate="({ detail: { dt }}) => this.object.rotation.x = this.object.rotation.z += 1 * dt"
             >
               <three-dodecahedron-buffer-geometry></three-dodecahedron-buffer-geometry>
               <three-mesh-standard-material color="yellow"></three-mesh-standard-material>
             </three-mesh>
           </three-group>
 
-          <three-group onupdate="dt => this.object.rotation.x = this.object.rotation.y += 2 * dt">
+          <three-group
+            onupdate="({ detail: { dt }}) => this.object.rotation.x = this.object.rotation.y += 2 * dt"
+          >
             <three-mesh
               position="0, 4, 0"
-              onupdate="dt => this.object.rotation.x = this.object.rotation.z += 1 * dt"
+              onupdate="({ detail: { dt }}) => this.object.rotation.x = this.object.rotation.z += 1 * dt"
             >
               <three-dodecahedron-buffer-geometry></three-dodecahedron-buffer-geometry>
               <three-mesh-standard-material color="green"></three-mesh-standard-material>
             </three-mesh>
           </three-group>
 
-          <three-group onupdate="dt => this.object.rotation.x = this.object.rotation.z += 2.5 * dt">
+          <three-group
+            onupdate="({ detail: { dt }}) => this.object.rotation.x = this.object.rotation.z += 2.5 * dt"
+          >
             <three-mesh
               position="0, -4, 0"
-              onupdate="dt => this.object.rotation.x = this.object.rotation.z += 1 * dt"
+              onupdate="({ detail: { dt }}) => this.object.rotation.x = this.object.rotation.z += 1 * dt"
             >
               <three-dodecahedron-buffer-geometry></three-dodecahedron-buffer-geometry>
               <three-mesh-standard-material color="blue"></three-mesh-standard-material>

--- a/examples/templates.html
+++ b/examples/templates.html
@@ -22,8 +22,8 @@
 
         <!-- Define a small helper function. -->
         <script type="module">
-          const rotate = (amount, object) => (dt) => {
-            object.rotation.z += amount * dt
+          const rotate = (amount, object) => (e) => {
+            object.rotation.z += amount * e.detail.dt
           }
 
           window.rotate = rotate

--- a/examples/templates.html
+++ b/examples/templates.html
@@ -30,10 +30,10 @@
         </script>
 
         <!-- A bunch of rotating cubes. They're really dodecahedrons, sorry! -->
-        <rotating-cube position="+2, +2, 0" onupdate="rotate(1, this.object)"></rotating-cube>
-        <rotating-cube position="+2, -2, 0" onupdate="rotate(2, this.object)"></rotating-cube>
-        <rotating-cube position="-2, -2, 0" onupdate="rotate(-2, this.object)"></rotating-cube>
-        <rotating-cube position="-2, +2, 0" onupdate="rotate(-1, this.object)"></rotating-cube>
+        <rotating-cube position="+2, +2, 0" ontick="rotate(1, this.object)"></rotating-cube>
+        <rotating-cube position="+2, -2, 0" ontick="rotate(2, this.object)"></rotating-cube>
+        <rotating-cube position="-2, -2, 0" ontick="rotate(-2, this.object)"></rotating-cube>
+        <rotating-cube position="-2, +2, 0" ontick="rotate(-1, this.object)"></rotating-cube>
 
         <three-orbit-controls></three-orbit-controls>
       </three-scene>

--- a/examples/templates.html
+++ b/examples/templates.html
@@ -23,7 +23,7 @@
         <!-- Define a small helper function. -->
         <script type="module">
           const rotate = (amount, object) => (e) => {
-            object.rotation.z += amount * e.detail.dt
+            object.rotation.z += amount * e.detail.deltaTime
           }
 
           window.rotate = rotate

--- a/examples/ticker-events.html
+++ b/examples/ticker-events.html
@@ -27,9 +27,11 @@
 
     <!-- Import dependencies via ESM. The future is now! -->
     <script type="module">
+      document.addEventListener("connected", (e) => console.log(e))
+
       importShim("/dist/index.esm.js").then(() => {
-        // const game = document.getElementById("game")
-        // const mesh = document.getElementById("mesh")
+        const game = document.getElementById("game")
+        const mesh = document.getElementById("mesh")
         // game.addEventListener("update", (e) => {
         //   const { dt } = e.detail
         //   console.log("update!")

--- a/examples/ticker-events.html
+++ b/examples/ticker-events.html
@@ -16,8 +16,7 @@
         <three-mesh
           scale="2.5"
           id="mesh"
-          ticking
-          ontick="({ detail: { dt }}, { object }) => { object.rotateZ(3 * dt); game.requestFrame() }"
+          ontick="({target}) => { target.object.rotateZ(3 * game.deltaTime); game.requestFrame() }"
         >
           <three-dodecahedron-buffer-geometry></three-dodecahedron-buffer-geometry>
           <three-mesh-standard-material color="#a63"></three-mesh-standard-material>
@@ -27,18 +26,7 @@
 
     <!-- Import dependencies via ESM. The future is now! -->
     <script type="module">
-      document.addEventListener("connected", (e) => console.log(e))
-
-      importShim("/dist/index.esm.js").then(() => {
-        const game = document.getElementById("game")
-        const mesh = document.getElementById("mesh")
-        // game.addEventListener("update", (e) => {
-        //   const { dt } = e.detail
-        //   console.log("update!")
-        //   mesh.object.rotation.x = mesh.object.rotation.y += 3 * dt
-        //   game.requestFrame()
-        // })
-      })
+      importShim("/dist/index.esm.js")
     </script>
     <script type="importmap-shim">
       {

--- a/examples/ticker-events.html
+++ b/examples/ticker-events.html
@@ -14,7 +14,7 @@
         <three-directional-light intensity="0.8" position="10, 10, 50"></three-directional-light>
 
         <!-- Scene Contents -->
-        <three-mesh scale="2.5">
+        <three-mesh scale="2.5" id="mesh">
           <three-dodecahedron-buffer-geometry></three-dodecahedron-buffer-geometry>
           <three-mesh-standard-material color="#a63"></three-mesh-standard-material>
         </three-mesh>
@@ -25,8 +25,13 @@
     <script type="module">
       importShim("/dist/index.esm.js").then(() => {
         const game = document.getElementById("game")
-        game.addEventListener("tick", (e) => {
-          console.log("tick!")
+        const mesh = document.getElementById("mesh")
+
+        game.addEventListener("update", (e) => {
+          const { dt } = e.detail
+          console.log("update!")
+          mesh.object.rotation.x = mesh.object.rotation.y += 3 * dt
+          game.requestFrame()
         })
       })
     </script>

--- a/examples/ticker-events.html
+++ b/examples/ticker-events.html
@@ -17,7 +17,7 @@
           scale="2.5"
           id="mesh"
           ticking
-          onupdate="({ detail: { dt }}, { object }) => { object.rotateZ(3 * dt); game.requestFrame() }"
+          ontick="({ detail: { dt }}, { object }) => { object.rotateZ(3 * dt); game.requestFrame() }"
         >
           <three-dodecahedron-buffer-geometry></three-dodecahedron-buffer-geometry>
           <three-mesh-standard-material color="#a63"></three-mesh-standard-material>

--- a/examples/ticker-events.html
+++ b/examples/ticker-events.html
@@ -1,0 +1,43 @@
+<html>
+  <head>
+    <title>Ticker Events</title>
+    <link rel="stylesheet" href="/styles.css" />
+    <script type="module" src="https://jspm.dev/es-module-shims"></script>
+  </head>
+  <body>
+    <!-- Here's a simple Three.js scene. Note that we're setting the "autorender" attribute
+    to make sure that a frame is rendered every tick. -->
+    <three-game id="game">
+      <three-scene background-color="#433">
+        <!-- Lights -->
+        <three-ambient-light intensity="0.2"></three-ambient-light>
+        <three-directional-light intensity="0.8" position="10, 10, 50"></three-directional-light>
+
+        <!-- Scene Contents -->
+        <three-mesh scale="2.5">
+          <three-dodecahedron-buffer-geometry></three-dodecahedron-buffer-geometry>
+          <three-mesh-standard-material color="#a63"></three-mesh-standard-material>
+        </three-mesh>
+      </three-scene>
+    </three-game>
+
+    <!-- Import dependencies via ESM. The future is now! -->
+    <script type="module">
+      importShim("/dist/index.esm.js").then(() => {
+        const game = document.getElementById("game")
+        game.addEventListener("tick", (e) => {
+          console.log("tick!")
+        })
+      })
+    </script>
+    <script type="importmap-shim">
+      {
+        "imports": {
+          "eventemitter3": "https://jspm.dev/eventemitter3",
+          "three": "https://jspm.dev/three",
+          "three/": "https://jspm.dev/three/"
+        }
+      }
+    </script>
+  </body>
+</html>

--- a/examples/ticker-events.html
+++ b/examples/ticker-events.html
@@ -16,6 +16,7 @@
         <three-mesh
           scale="2.5"
           id="mesh"
+          ticking
           onupdate="({ detail: { dt }}, { object }) => { object.rotateZ(3 * dt); game.requestFrame() }"
         >
           <three-dodecahedron-buffer-geometry></three-dodecahedron-buffer-geometry>

--- a/examples/ticker-events.html
+++ b/examples/ticker-events.html
@@ -5,16 +5,19 @@
     <script type="module" src="https://jspm.dev/es-module-shims"></script>
   </head>
   <body>
-    <!-- Here's a simple Three.js scene. Note that we're setting the "autorender" attribute
-    to make sure that a frame is rendered every tick. -->
     <three-game id="game">
       <three-scene background-color="#433">
         <!-- Lights -->
         <three-ambient-light intensity="0.2"></three-ambient-light>
         <three-directional-light intensity="0.8" position="10, 10, 50"></three-directional-light>
+        <three-orbit-controls></three-orbit-controls>
 
         <!-- Scene Contents -->
-        <three-mesh scale="2.5" id="mesh" onupdate="e => console.log(e.detail.dt)">
+        <three-mesh
+          scale="2.5"
+          id="mesh"
+          onupdate="({ detail: { dt }}, { object }) => { object.rotateZ(3 * dt); game.requestFrame() }"
+        >
           <three-dodecahedron-buffer-geometry></three-dodecahedron-buffer-geometry>
           <three-mesh-standard-material color="#a63"></three-mesh-standard-material>
         </three-mesh>
@@ -24,9 +27,8 @@
     <!-- Import dependencies via ESM. The future is now! -->
     <script type="module">
       importShim("/dist/index.esm.js").then(() => {
-        const game = document.getElementById("game")
-        const mesh = document.getElementById("mesh")
-
+        // const game = document.getElementById("game")
+        // const mesh = document.getElementById("mesh")
         // game.addEventListener("update", (e) => {
         //   const { dt } = e.detail
         //   console.log("update!")

--- a/examples/ticker-events.html
+++ b/examples/ticker-events.html
@@ -14,7 +14,7 @@
         <three-directional-light intensity="0.8" position="10, 10, 50"></three-directional-light>
 
         <!-- Scene Contents -->
-        <three-mesh scale="2.5" id="mesh">
+        <three-mesh scale="2.5" id="mesh" onupdate="e => console.log(e.detail.dt)">
           <three-dodecahedron-buffer-geometry></three-dodecahedron-buffer-geometry>
           <three-mesh-standard-material color="#a63"></three-mesh-standard-material>
         </three-mesh>
@@ -27,12 +27,12 @@
         const game = document.getElementById("game")
         const mesh = document.getElementById("mesh")
 
-        game.addEventListener("update", (e) => {
-          const { dt } = e.detail
-          console.log("update!")
-          mesh.object.rotation.x = mesh.object.rotation.y += 3 * dt
-          game.requestFrame()
-        })
+        // game.addEventListener("update", (e) => {
+        //   const { dt } = e.detail
+        //   console.log("update!")
+        //   mesh.object.rotation.x = mesh.object.rotation.y += 3 * dt
+        //   game.requestFrame()
+        // })
       })
     </script>
     <script type="importmap-shim">

--- a/examples/with-vue.html
+++ b/examples/with-vue.html
@@ -54,8 +54,8 @@
           mounted() {
             const { object, game } = this.$el
 
-            this.$el.ontick = ({ detail: { dt } }) => {
-              object.rotation.z = object.rotation.x += 3 * dt
+            this.$el.ontick = () => {
+              object.rotation.z = object.rotation.x += 3 * game.deltaTime
               object.scale.setScalar(4 + Math.cos(Date.now() / 200) * 0.8)
               game.requestFrame()
             }

--- a/examples/with-vue.html
+++ b/examples/with-vue.html
@@ -54,8 +54,8 @@
           mounted() {
             const { object, game } = this.$el
 
-            this.$el.onupdate = (dt) => {
-              object.rotation.z = object.rotation.x += 0.03
+            this.$el.onupdate = ({ detail: { dt } }) => {
+              object.rotation.z = object.rotation.x += 3 * dt
               object.scale.setScalar(4 + Math.cos(Date.now() / 200) * 0.8)
               game.requestFrame()
             }

--- a/examples/with-vue.html
+++ b/examples/with-vue.html
@@ -54,7 +54,7 @@
           mounted() {
             const { object, game } = this.$el
 
-            this.$el.onupdate = ({ detail: { dt } }) => {
+            this.$el.ontick = ({ detail: { dt } }) => {
               object.rotation.z = object.rotation.x += 3 * dt
               object.scale.setScalar(4 + Math.cos(Date.now() / 200) * 0.8)
               game.requestFrame()

--- a/package.json
+++ b/package.json
@@ -55,7 +55,5 @@
   "peerDependencies": {
     "three": ">=0.121.0"
   },
-  "dependencies": {
-    "eventemitter3": "^4.0.7"
-  }
+  "dependencies": {}
 }

--- a/site/src/Thingy.svelte
+++ b/site/src/Thingy.svelte
@@ -26,7 +26,7 @@
 </script>
 
 <!-- Mesh -->
-<three-mesh onupdate={rotateDeconstruct} {...$$restProps}>
+<three-mesh ontick={rotateDeconstruct} {...$$restProps}>
   <three-dodecahedron-buffer-geometry />
   <three-mesh-standard-material color="hotpink" />
 </three-mesh>

--- a/src/ThreeElement.ts
+++ b/src/ThreeElement.ts
@@ -287,11 +287,12 @@ export class ThreeElement<T> extends HTMLElement {
   }
 
   private setCallback(propName: string, fn?: TickerFunction | string) {
-    const eventName = propName.replace(/^on/, "")
+    const eventName = propName.replace(/^on/, "") as any
 
     /* Unregister previous callback */
-    if (this.callbacks[eventName]) {
-      this.game.events.removeListener(eventName, this.callbacks[eventName])
+    const previousCallback = this.callbacks[eventName]
+    if (previousCallback) {
+      this.game.removeEventListener(eventName, previousCallback)
     }
 
     const createCallbackFunction = (fn?: TickerFunction | string) => {
@@ -317,8 +318,9 @@ export class ThreeElement<T> extends HTMLElement {
     this.callbacks[eventName] = createCallbackFunction(fn)
 
     /* Register new callback */
-    if (this.callbacks[eventName]) {
-      setTimeout(() => this.game.events.on(eventName, this.callbacks[eventName]!))
+    const newCallback = this.callbacks[eventName]
+    if (newCallback) {
+      setTimeout(() => this.game.addEventListener(eventName, newCallback))
     }
   }
 

--- a/src/ThreeElement.ts
+++ b/src/ThreeElement.ts
@@ -3,6 +3,7 @@ import { ThreeGame, TickerFunction } from "./elements/three-game"
 import { ThreeScene } from "./elements/three-scene"
 import { IConstructable, isDisposable, IStringIndexable } from "./types"
 import { applyProps } from "./util/applyProps"
+import { forwardEvent } from "./util/forwardEvent"
 import { observeAttributeChange } from "./util/observeAttributeChange"
 
 export class ThreeElement<T> extends HTMLElement {
@@ -117,6 +118,9 @@ export class ThreeElement<T> extends HTMLElement {
     Also see: https://javascript.info/custom-elements#rendering-order
     */
     setTimeout(() => {
+      /* Subscribe to ticker events and mirror them */
+      this.game.addEventListener("update" as any, (e) => forwardEvent(this, e))
+
       /* Handle attach attribute */
       this.handleAttach()
 
@@ -137,6 +141,9 @@ export class ThreeElement<T> extends HTMLElement {
 
   disconnectedCallback() {
     this.debug("disconnectedCallback")
+
+    /* TODO: Stop listening to the game's ticker events */
+    // this.game.removeEventListener("update" as any, this.dispatchTickerEvent)
 
     /* If the wrapped object is parented, remove it from its parent */
     if (this.object instanceof THREE.Object3D && this.object.parent) {
@@ -292,7 +299,7 @@ export class ThreeElement<T> extends HTMLElement {
     /* Unregister previous callback */
     const previousCallback = this.callbacks[eventName]
     if (previousCallback) {
-      this.game.removeEventListener(eventName, previousCallback)
+      this.removeEventListener(eventName, previousCallback)
     }
 
     const createCallbackFunction = (fn?: TickerFunction | string) => {
@@ -320,7 +327,7 @@ export class ThreeElement<T> extends HTMLElement {
     /* Register new callback */
     const newCallback = this.callbacks[eventName]
     if (newCallback) {
-      setTimeout(() => this.game.addEventListener(eventName, newCallback))
+      setTimeout(() => this.addEventListener(eventName, newCallback))
     }
   }
 

--- a/src/ThreeElement.ts
+++ b/src/ThreeElement.ts
@@ -102,6 +102,9 @@ export class ThreeElement<T> extends HTMLElement {
       this.handleAttributeChange({ [prop]: value })
     })
 
+    /* Emit connected event */
+    this.dispatchEvent(new CustomEvent("connected", { bubbles: true, cancelable: false }))
+
     /*
     Some stuff relies on all custom elements being fully defined and connected. However:
 
@@ -130,6 +133,9 @@ export class ThreeElement<T> extends HTMLElement {
       /* Invoke mount method */
       this.readyCallback()
 
+      /* Emit ready event */
+      this.dispatchEvent(new CustomEvent("ready", { bubbles: true, cancelable: false }))
+
       this.debug("Object is ready:", this.object)
     })
   }
@@ -138,6 +144,9 @@ export class ThreeElement<T> extends HTMLElement {
 
   disconnectedCallback() {
     this.debug("disconnectedCallback")
+
+    /* Emit disconnected event */
+    this.dispatchEvent(new CustomEvent("disconnected", { bubbles: true, cancelable: false }))
 
     /* TODO: Stop listening to the game's ticker events */
     // this.game.removeEventListener("update" as any, this.dispatchTickerEvent)

--- a/src/ThreeElement.ts
+++ b/src/ThreeElement.ts
@@ -118,9 +118,6 @@ export class ThreeElement<T> extends HTMLElement {
     Also see: https://javascript.info/custom-elements#rendering-order
     */
     setTimeout(() => {
-      /* Subscribe to ticker events and mirror them */
-      this.game.addEventListener("update" as any, (e) => forwardEvent(this, e))
-
       /* Handle attach attribute */
       this.handleAttach()
 
@@ -248,7 +245,18 @@ export class ThreeElement<T> extends HTMLElement {
   }
 
   private handleAttributeChange(attributes: IStringIndexable) {
-    const { attach, args, ...remainingAttributes } = attributes
+    const { attach, args, ticking, ...remainingAttributes } = attributes
+
+    /*
+    "ticking" will make the element subscribe to the game's ticker events.
+    */
+    if (ticking !== undefined) {
+      this.debug("ticking is set; subscribing to game's ticker events")
+      this.game.addEventListener("update" as any, (e) => forwardEvent(this, e))
+      this.game.addEventListener("lateupdate" as any, (e) => forwardEvent(this, e))
+      this.game.addEventListener("frame" as any, (e) => forwardEvent(this, e))
+      this.game.addEventListener("render" as any, (e) => forwardEvent(this, e))
+    }
 
     /*
     When pointer event handlers are set as attributes, we'll construct new function from them. Typically,

--- a/src/ThreeElement.ts
+++ b/src/ThreeElement.ts
@@ -17,7 +17,7 @@ export class ThreeElement<T> extends HTMLElement {
   /** The THREE.* object managed by this element. */
   object?: T
 
-  /** A dictionary of ticker callbacks (onupdate, etc.) */
+  /** A dictionary of ticker callbacks (ontick, etc.) */
   private callbacks = {} as Record<string, TickerFunction | undefined>
 
   /**
@@ -27,36 +27,36 @@ export class ThreeElement<T> extends HTMLElement {
     return `<${this.tagName.toLowerCase()}>`
   }
 
-  get onupdate() {
-    return this.callbacks["onupdate"]
+  get ontick() {
+    return this.callbacks["ontick"]
   }
 
-  set onupdate(fn: TickerFunction | string | undefined) {
-    this.setCallback("onupdate", fn)
+  set ontick(fn: TickerFunction | string | undefined) {
+    this.setCallback("ontick", fn)
   }
 
-  get onlateupdate() {
-    return this.callbacks["onlateupdate"]
+  get onlatetick() {
+    return this.callbacks["onlatetick"]
   }
 
-  set onlateupdate(fn: TickerFunction | string | undefined) {
-    this.setCallback("onlateupdate", fn)
+  set onlatetick(fn: TickerFunction | string | undefined) {
+    this.setCallback("onlatetick", fn)
   }
 
-  get onframe() {
-    return this.callbacks["onframe"]
+  get onframetick() {
+    return this.callbacks["onframetick"]
   }
 
-  set onframe(fn: TickerFunction | string | undefined) {
-    this.setCallback("onframe", fn)
+  set onframetick(fn: TickerFunction | string | undefined) {
+    this.setCallback("onframetick", fn)
   }
 
-  get onrender() {
-    return this.callbacks["onrender"]
+  get onrendertick() {
+    return this.callbacks["onrendertick"]
   }
 
-  set onrender(fn: TickerFunction | string | undefined) {
-    this.setCallback("onrender", fn)
+  set onrendertick(fn: TickerFunction | string | undefined) {
+    this.setCallback("onrendertick", fn)
   }
 
   /**
@@ -80,17 +80,17 @@ export class ThreeElement<T> extends HTMLElement {
     if (v) {
       this.debug("ticking is set; subscribing to game's ticker events")
 
-      this.game.addEventListener("update" as any, this._forwarder)
-      this.game.addEventListener("lateupdate" as any, this._forwarder)
-      this.game.addEventListener("frame" as any, this._forwarder)
-      this.game.addEventListener("render" as any, this._forwarder)
+      this.game.addEventListener("tick" as any, this._forwarder)
+      this.game.addEventListener("latetick" as any, this._forwarder)
+      this.game.addEventListener("frametick" as any, this._forwarder)
+      this.game.addEventListener("rendertick" as any, this._forwarder)
     } else {
       this.debug("Unregistering ticker listeners")
 
-      this.game.removeEventListener("update" as any, this._forwarder)
-      this.game.removeEventListener("lateupdate" as any, this._forwarder)
-      this.game.removeEventListener("frame" as any, this._forwarder)
-      this.game.removeEventListener("render" as any, this._forwarder)
+      this.game.removeEventListener("tick" as any, this._forwarder)
+      this.game.removeEventListener("latetick" as any, this._forwarder)
+      this.game.removeEventListener("frametick" as any, this._forwarder)
+      this.game.removeEventListener("rendertick" as any, this._forwarder)
     }
   }
   private _forwarder = eventForwarder(this)
@@ -297,10 +297,10 @@ export class ThreeElement<T> extends HTMLElement {
     switch (key) {
       /* A bunch of known properties that we will assign directly */
       case "ticking":
-      case "onupdate":
-      case "onlateupdate":
-      case "onframe":
-      case "onrender":
+      case "ontick":
+      case "onlatetick":
+      case "onframetick":
+      case "onrendertick":
         this[key] = newValue
         break
 

--- a/src/ThreeElement.ts
+++ b/src/ThreeElement.ts
@@ -6,6 +6,8 @@ import { applyProps } from "./util/applyProps"
 import { forwardEvent } from "./util/forwardEvent"
 import { observeAttributeChange } from "./util/observeAttributeChange"
 
+export class ThreeElementLifecycleEvent extends CustomEvent<{}> {}
+
 export class ThreeElement<T> extends HTMLElement {
   /** The THREE.* object managed by this element. */
   object?: T
@@ -103,7 +105,9 @@ export class ThreeElement<T> extends HTMLElement {
     })
 
     /* Emit connected event */
-    this.dispatchEvent(new CustomEvent("connected", { bubbles: true, cancelable: false }))
+    this.dispatchEvent(
+      new ThreeElementLifecycleEvent("connected", { bubbles: true, cancelable: false })
+    )
 
     /*
     Some stuff relies on all custom elements being fully defined and connected. However:
@@ -134,7 +138,9 @@ export class ThreeElement<T> extends HTMLElement {
       this.readyCallback()
 
       /* Emit ready event */
-      this.dispatchEvent(new CustomEvent("ready", { bubbles: true, cancelable: false }))
+      this.dispatchEvent(
+        new ThreeElementLifecycleEvent("ready", { bubbles: true, cancelable: false })
+      )
 
       this.debug("Object is ready:", this.object)
     })
@@ -146,7 +152,9 @@ export class ThreeElement<T> extends HTMLElement {
     this.debug("disconnectedCallback")
 
     /* Emit disconnected event */
-    this.dispatchEvent(new CustomEvent("disconnected", { bubbles: true, cancelable: false }))
+    this.dispatchEvent(
+      new ThreeElementLifecycleEvent("disconnected", { bubbles: true, cancelable: false })
+    )
 
     /* TODO: Stop listening to the game's ticker events */
     // this.game.removeEventListener("update" as any, this.dispatchTickerEvent)

--- a/src/ThreeElement.ts
+++ b/src/ThreeElement.ts
@@ -80,17 +80,17 @@ export class ThreeElement<T> extends HTMLElement {
     if (v) {
       this.debug("ticking is set; subscribing to game's ticker events")
 
-      this.game.addEventListener("tick" as any, this._forwarder)
-      this.game.addEventListener("latetick" as any, this._forwarder)
-      this.game.addEventListener("frametick" as any, this._forwarder)
-      this.game.addEventListener("rendertick" as any, this._forwarder)
+      this.game.addEventListener("tick", this._forwarder)
+      this.game.addEventListener("latetick", this._forwarder)
+      this.game.addEventListener("frametick", this._forwarder)
+      this.game.addEventListener("rendertick", this._forwarder)
     } else {
       this.debug("Unregistering ticker listeners")
 
-      this.game.removeEventListener("tick" as any, this._forwarder)
-      this.game.removeEventListener("latetick" as any, this._forwarder)
-      this.game.removeEventListener("frametick" as any, this._forwarder)
-      this.game.removeEventListener("rendertick" as any, this._forwarder)
+      this.game.removeEventListener("tick", this._forwarder)
+      this.game.removeEventListener("latetick", this._forwarder)
+      this.game.removeEventListener("frametick", this._forwarder)
+      this.game.removeEventListener("rendertick", this._forwarder)
     }
   }
   private _forwarder = eventForwarder(this)

--- a/src/elements/three-game.ts
+++ b/src/elements/three-game.ts
@@ -4,7 +4,7 @@ import { registerElement } from "../util/registerElement"
 
 export type TickerFunction = (dt: number, element?: ThreeElement<any>) => any
 
-export const CALLBACKS = new Set<string>(["onupdate", "onlateupdate", "onframe", "onrender"])
+export const CALLBACKS = new Set<string>(["ontick", "onlatetick", "onframetick", "onrendertick"])
 
 export class ThreeGame extends HTMLElement {
   renderer = new THREE.WebGLRenderer({
@@ -106,19 +106,19 @@ export class ThreeGame extends HTMLElement {
       const dt = (now - lastNow) / 1000
       lastNow = now
 
-      /* Execute update and lateupdate events. */
-      dispatch("update", dt)
-      dispatch("lateupdate", dt)
+      /* Execute tick and latetick events. */
+      dispatch("tick", dt)
+      dispatch("latetick", dt)
 
       /* Has a frame been requested? */
       if (this.frameRequested || this.autorender) {
         this.frameRequested = false
 
         /* If we know that we're rendering a frame, execute frame callbacks. */
-        dispatch("frame", dt)
+        dispatch("frametick", dt)
 
         /* Finally, emit render event. This will trigger scenes to render. */
-        dispatch("render", dt)
+        dispatch("rendertick", dt)
       }
 
       /* Loop as long as this ticker is active. */

--- a/src/elements/three-game.ts
+++ b/src/elements/three-game.ts
@@ -98,6 +98,11 @@ export class ThreeGame extends HTMLElement {
   startTicking() {
     let lastNow = performance.now()
 
+    const dispatch = (name: string, dt: number) =>
+      this.dispatchEvent(
+        new CustomEvent(name, { bubbles: false, cancelable: false, detail: { dt } })
+      )
+
     const tick = () => {
       /*
       Figure out deltatime. This is a very naive way of doing this, we'll eventually
@@ -108,7 +113,8 @@ export class ThreeGame extends HTMLElement {
       lastNow = now
 
       /* EXPERIMENTAL new DOM Event-based ticking */
-      this.dispatchEvent(new CustomEvent("tick", { bubbles: false, cancelable: false }))
+      dispatch("update", dt)
+      dispatch("lateupdate", dt)
 
       /* Execute update and lateupdate callbacls. */
       this.events.emit("update", dt)
@@ -119,9 +125,11 @@ export class ThreeGame extends HTMLElement {
         this.frameRequested = false
 
         /* If we know that we're rendering a frame, execute frame callbacks. */
+        dispatch("frame", dt)
         this.events.emit("frame", dt)
 
         /* Finally, emit render event. This will trigger scenes to render. */
+        dispatch("render", dt)
         this.events.emit("render", dt)
       }
 

--- a/src/elements/three-game.ts
+++ b/src/elements/three-game.ts
@@ -107,6 +107,9 @@ export class ThreeGame extends HTMLElement {
       const dt = (now - lastNow) / 1000
       lastNow = now
 
+      /* EXPERIMENTAL new DOM Event-based ticking */
+      this.dispatchEvent(new CustomEvent("tick", { bubbles: false, cancelable: false }))
+
       /* Execute update and lateupdate callbacls. */
       this.events.emit("update", dt)
       this.events.emit("lateupdate", dt)

--- a/src/elements/three-game.ts
+++ b/src/elements/three-game.ts
@@ -1,4 +1,3 @@
-import EventEmitter from "eventemitter3"
 import * as THREE from "three"
 import { ThreeElement } from "../ThreeElement"
 import { registerElement } from "../util/registerElement"
@@ -14,8 +13,6 @@ export class ThreeGame extends HTMLElement {
     stencil: true,
     depth: true
   })
-
-  events = new EventEmitter()
 
   /** Is the ticker running? */
   private ticking = false
@@ -86,9 +83,6 @@ export class ThreeGame extends HTMLElement {
 
     /* Update canvas */
     this.renderer.setSize(width, height)
-
-    /* Emit event */
-    this.events.emit("resize")
   }
 
   requestFrame() {
@@ -112,13 +106,9 @@ export class ThreeGame extends HTMLElement {
       const dt = (now - lastNow) / 1000
       lastNow = now
 
-      /* EXPERIMENTAL new DOM Event-based ticking */
+      /* Execute update and lateupdate events. */
       dispatch("update", dt)
       dispatch("lateupdate", dt)
-
-      /* Execute update and lateupdate callbacls. */
-      this.events.emit("update", dt)
-      this.events.emit("lateupdate", dt)
 
       /* Has a frame been requested? */
       if (this.frameRequested || this.autorender) {
@@ -126,11 +116,9 @@ export class ThreeGame extends HTMLElement {
 
         /* If we know that we're rendering a frame, execute frame callbacks. */
         dispatch("frame", dt)
-        this.events.emit("frame", dt)
 
         /* Finally, emit render event. This will trigger scenes to render. */
         dispatch("render", dt)
-        this.events.emit("render", dt)
       }
 
       /* Loop as long as this ticker is active. */

--- a/src/elements/three-game.ts
+++ b/src/elements/three-game.ts
@@ -4,7 +4,7 @@ import { registerElement } from "../util/registerElement"
 
 export type TickerFunction = (dt: number, element?: ThreeElement<any>) => any
 
-export const CALLBACKS = new Set<string>(["ontick", "onlatetick", "onframetick", "onrendertick"])
+export class TickerEvent extends CustomEvent<{ dt: number }> {}
 
 export class ThreeGame extends HTMLElement {
   renderer = new THREE.WebGLRenderer({
@@ -16,6 +16,9 @@ export class ThreeGame extends HTMLElement {
 
   /** Is the ticker running? */
   private ticking = false
+
+  /** The time delta since the last frame, in fractions of a second. */
+  deltaTime = 0
 
   /** Has a frame been requested to be rendered in the next tick? */
   private frameRequested = true
@@ -94,7 +97,7 @@ export class ThreeGame extends HTMLElement {
 
     const dispatch = (name: string, dt: number) =>
       this.dispatchEvent(
-        new CustomEvent(name, { bubbles: false, cancelable: false, detail: { dt } })
+        new TickerEvent(name, { bubbles: false, cancelable: false, detail: { dt } })
       )
 
     const tick = () => {
@@ -105,6 +108,9 @@ export class ThreeGame extends HTMLElement {
       const now = performance.now()
       const dt = (now - lastNow) / 1000
       lastNow = now
+
+      /* Store deltaTime on instance for easy access */
+      this.deltaTime = dt
 
       /* Execute tick and latetick events. */
       dispatch("tick", dt)

--- a/src/elements/three-game.ts
+++ b/src/elements/three-game.ts
@@ -4,7 +4,7 @@ import { registerElement } from "../util/registerElement"
 
 export type TickerFunction = (dt: number, element?: ThreeElement<any>) => any
 
-export class TickerEvent extends CustomEvent<{ dt: number }> {}
+export class TickerEvent extends CustomEvent<{ deltaTime: number }> {}
 
 export class ThreeGame extends HTMLElement {
   renderer = new THREE.WebGLRenderer({
@@ -95,9 +95,9 @@ export class ThreeGame extends HTMLElement {
   startTicking() {
     let lastNow = performance.now()
 
-    const dispatch = (name: string, dt: number) =>
+    const dispatch = (name: string, deltaTime: number) =>
       this.dispatchEvent(
-        new TickerEvent(name, { bubbles: false, cancelable: false, detail: { dt } })
+        new TickerEvent(name, { bubbles: false, cancelable: false, detail: { deltaTime } })
       )
 
     const tick = () => {

--- a/src/elements/three-gltf-asset.ts
+++ b/src/elements/three-gltf-asset.ts
@@ -4,9 +4,7 @@ import { ThreeElement } from "../ThreeElement"
 import { registerElement } from "../util/registerElement"
 
 export class ThreeGLTFAsset extends ThreeElement.for(Group) {
-  static get observedAttributes() {
-    return ["url"]
-  }
+  static observedAttributes = ["url"]
 
   public get url() {
     return this.getAttribute("url")
@@ -24,12 +22,6 @@ export class ThreeGLTFAsset extends ThreeElement.for(Group) {
         this.object!.add(gltf.scene)
         this.game.requestFrame()
       })
-    }
-  }
-
-  attributeChangedCallback(name: string, _oldValue: string, newValue: string) {
-    if (name === "url") {
-      this.url = newValue
     }
   }
 }

--- a/src/elements/three-orbit-controls.ts
+++ b/src/elements/three-orbit-controls.ts
@@ -10,7 +10,7 @@ export class ThreeOrbitControls extends ThreeElement<OrbitControls> {
     let { camera } = this.scene
     this.controls = new OrbitControls(camera, renderer.domElement)
 
-    this.onupdate = () => {
+    this.ontick = () => {
       if (!this.controls) return
 
       /*

--- a/src/elements/three-scene.ts
+++ b/src/elements/three-scene.ts
@@ -43,27 +43,31 @@ export class ThreeScene extends ThreeElement.for(Scene) {
 
     /* Handle window resizing */
     this.handleWindowResize = this.handleWindowResize.bind(this)
-    this.game.events.on("resize", this.handleWindowResize)
+    window.addEventListener("resize", this.handleWindowResize)
     this.handleWindowResize()
 
     /* Configure scene */
     const scene = this.object!
 
     /* Set up rendering */
-    this.game.events.on("render", (dt) => {
-      const { renderer } = this.game
-
-      renderer.clearDepth()
-      renderer.render(scene, this.camera)
-    })
+    this.render = this.render.bind(this)
+    this.game.addEventListener("update", this.render)
 
     /* Start processing events */
     this.pointer!.start()
   }
 
+  render() {
+    const { renderer } = this.game
+
+    renderer.clearDepth()
+    renderer.render(this.object!, this.camera)
+  }
+
   disconnectedCallback() {
     /* Unregister event handlers */
-    this.game.events.off("resize", this.handleWindowResize)
+    this.game.removeEventListener("update", this.render)
+    window.removeEventListener("resize", this.handleWindowResize)
   }
 
   attributeChangedCallback(name: string, oldValue: string, newValue: string) {

--- a/src/elements/three-scene.ts
+++ b/src/elements/three-scene.ts
@@ -54,7 +54,7 @@ export class ThreeScene extends ThreeElement.for(Scene) {
 
     /* Set up rendering */
     this.render = this.render.bind(this)
-    this.game.addEventListener("render", this.render)
+    this.game.addEventListener("rendertick", this.render)
 
     /* Start processing events */
     this.pointer!.start()
@@ -69,7 +69,7 @@ export class ThreeScene extends ThreeElement.for(Scene) {
 
   disconnectedCallback() {
     /* Unregister event handlers */
-    this.game.removeEventListener("render", this.render)
+    this.game.removeEventListener("rendertick", this.render)
     window.removeEventListener("resize", this.handleWindowResize)
   }
 

--- a/src/elements/three-scene.ts
+++ b/src/elements/three-scene.ts
@@ -49,9 +49,6 @@ export class ThreeScene extends ThreeElement.for(Scene) {
     window.addEventListener("resize", this.handleWindowResize)
     this.handleWindowResize()
 
-    /* Configure scene */
-    const scene = this.object!
-
     /* Set up rendering */
     this.render = this.render.bind(this)
     this.game.addEventListener("rendertick", this.render)
@@ -77,7 +74,7 @@ export class ThreeScene extends ThreeElement.for(Scene) {
     switch (name) {
       case "background-color":
         this.object!.background = new Color(newValue)
-        break
+        return
 
       case "camera":
         setTimeout(() => {
@@ -92,8 +89,10 @@ export class ThreeScene extends ThreeElement.for(Scene) {
             this.camera.lookAt(0, 0, 0)
           }
         })
-        break
+        return
     }
+
+    super.attributeChangedCallback(name, oldValue, newValue)
   }
 
   handleWindowResize() {

--- a/src/elements/three-scene.ts
+++ b/src/elements/three-scene.ts
@@ -22,8 +22,11 @@ export class ThreeScene extends ThreeElement.for(Scene) {
 
   set camera(camera) {
     this._camera = camera
-    this.pointer!.camera = camera
-    this.handleWindowResize()
+
+    if (this.isReady) {
+      this.pointer!.camera = camera
+      this.handleWindowResize()
+    }
   }
 
   /** The pointer events system. */

--- a/src/elements/three-scene.ts
+++ b/src/elements/three-scene.ts
@@ -51,7 +51,7 @@ export class ThreeScene extends ThreeElement.for(Scene) {
 
     /* Set up rendering */
     this.render = this.render.bind(this)
-    this.game.addEventListener("update", this.render)
+    this.game.addEventListener("render", this.render)
 
     /* Start processing events */
     this.pointer!.start()
@@ -66,7 +66,7 @@ export class ThreeScene extends ThreeElement.for(Scene) {
 
   disconnectedCallback() {
     /* Unregister event handlers */
-    this.game.removeEventListener("update", this.render)
+    this.game.removeEventListener("render", this.render)
     window.removeEventListener("resize", this.handleWindowResize)
   }
 

--- a/src/util/eventForwarder.ts
+++ b/src/util/eventForwarder.ts
@@ -1,2 +1,8 @@
-export const eventForwarder = (element: HTMLElement) => (event: Event) =>
-  element.dispatchEvent(new CustomEvent(event.type, event))
+export const eventForwarder = (element: HTMLElement) => (originalEvent: Event) => {
+  element.dispatchEvent(cloneEvent(originalEvent))
+}
+
+export const cloneEvent = (originalEvent: Event) => {
+  const eventClass = originalEvent.constructor as typeof Event
+  return new eventClass(originalEvent.type, originalEvent)
+}

--- a/src/util/eventForwarder.ts
+++ b/src/util/eventForwarder.ts
@@ -1,0 +1,2 @@
+export const eventForwarder = (element: HTMLElement) => (event: Event) =>
+  element.dispatchEvent(new CustomEvent(event.type, event))

--- a/src/util/eventForwarder.ts
+++ b/src/util/eventForwarder.ts
@@ -1,8 +1,10 @@
-export const eventForwarder = (element: HTMLElement) => (originalEvent: Event) => {
+import { IConstructable } from "../types"
+
+export const eventForwarder = (element: HTMLElement) => <T extends Event>(originalEvent: T) => {
   element.dispatchEvent(cloneEvent(originalEvent))
 }
 
-export const cloneEvent = (originalEvent: Event) => {
-  const eventClass = originalEvent.constructor as typeof Event
+export const cloneEvent = <T extends Event>(originalEvent: T) => {
+  const eventClass = originalEvent.constructor as IConstructable<T>
   return new eventClass(originalEvent.type, originalEvent)
 }

--- a/src/util/forwardEvent.ts
+++ b/src/util/forwardEvent.ts
@@ -1,0 +1,2 @@
+export const forwardEvent = (element: HTMLElement, event: Event) =>
+  element.dispatchEvent(new CustomEvent(event.type, event))

--- a/src/util/forwardEvent.ts
+++ b/src/util/forwardEvent.ts
@@ -1,2 +1,0 @@
-export const forwardEvent = (element: HTMLElement, event: Event) =>
-  element.dispatchEvent(new CustomEvent(event.type, event))

--- a/yarn.lock
+++ b/yarn.lock
@@ -1789,7 +1789,7 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-eventemitter3@^4.0.4, eventemitter3@^4.0.7:
+eventemitter3@^4.0.4:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==


### PR DESCRIPTION
**Why?**

- make things less surprising
- improve framework compatibility (some frameworks translate the setting of an `onfoo` attribute to a `addEventListener("foo")` call)
- remove one of the only two dependencies we have (eventemitter3)

**Steps:**

- [x] remove eventemitter3 dependency
- [x] Have ThreeGame emit events as custom DOM events
- [x] Have ThreeElement subscribe to these and emit their own event
- [x] Introduce a `ticking` attribute on elements that needs to be set in order for the element to emit ticker events
- [x] Maybe introduce our own event class that inherits from CustomEvent?
- [x] Expose `ticking` as a property, too
- [x] Automatically set `ticking = true` once an event handler is registered

**Cleanup:**

- [x] refactor `PointerEvents` class to make use of new `eventForwarder` helper
- [x] make sure that event handlers are cleanly removed when the element is disconnected. Elements might want to emit "connected" and "disconnected" DOM events and hook into those (once = true)?

**Deferred:**

- [x] Rename events to be more game- and three-elements specific. `onupdate` specifically bears a high risk of colliding with something that might have a meaning in other frameworks. Suggestion: `ontick`, `onlatetick`, `onframetick` and `onrendertick`?
- [x] Refactor `handleAttributeChange` to be less horrible
- [x] Provide access to deltaTime that is more convenient than destructuring the DOM events