### PR TITLE
Added XR attribute to three-game to enable WebXR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-- **Changed:** The core ticker loop now makes use of `setAnimationLoop` instead of `requestAnimationFrame`, which is a critical prerequisite for making your three-elements project [WebXR-ready](https://threejs.org/docs/#manual/en/introduction/How-to-create-VR-content).
+- **Changed:** The core ticker loop now makes use of `setAnimationLoop` instead of `requestAnimationFrame`, which is a critical prerequisite for making your three-elements project [WebXR-ready](https://three-elements.hmans.co/advanced/webxr.html).
+
+- **New:** `<three-game>` now can receive an `xr` attribute to enable WebXR features.
 
 ## [0.2.0] - 2021-01-18
 

--- a/examples/vr.html
+++ b/examples/vr.html
@@ -5,7 +5,7 @@
     <script type="module" src="https://jspm.dev/es-module-shims"></script>
   </head>
   <body>
-    <three-game autorender id="game">
+    <three-game autorender xr id="game">
       <three-scene background-color="#ffe" id="mainScene">
         <!-- Lights -->
         <three-ambient-light intensity="0.2"></three-ambient-light>
@@ -41,9 +41,6 @@
 
         /* Move camera way back */
         mainScene.camera.position.set(0, 0, 50)
-
-        /* Tell the renderer that we want XR */
-        renderer.xr.enabled = true
 
         /* Add the VR button */
         document.body.appendChild(VRButton.createButton(game.renderer))

--- a/site/docs/.vuepress/config.js
+++ b/site/docs/.vuepress/config.js
@@ -87,7 +87,8 @@ module.exports = {
         children: [
           "/advanced/stacked-scenes",
           "/advanced/optimized-rendering",
-          "/advanced/frameworks"
+          "/advanced/frameworks",
+          "/advanced/webxr"
         ]
       }
     ]

--- a/site/docs/advanced/webxr.md
+++ b/site/docs/advanced/webxr.md
@@ -1,0 +1,57 @@
+# WebXR
+
+## Workflow
+
+three-elements makes it easy to get started with WebXR.
+
+You can enable WebXR features by adding the `xr` attribute to `<three-game>` (Just make sure that you also enable `autorender`).
+
+```html
+<three-game id="game" autorender xr>
+  <three-scene background-color="#808080">
+    <three-ambient-light intensity="1.2"></three-ambient-light>
+
+    <three-mesh scale="4" rotation.x="-1.5707">
+      <three-plane-buffer-geometry></three-plane-buffer-geometry>
+      <three-mesh-standard-material color="#eeeeee"></three-mesh-standard-material>
+    </three-mesh>
+  </three-scene>
+</three-game>
+```
+
+Now that your app renders in XR, you have to create a way for users to step into a WebXR session. Luckily, three.js has a [built-in VR button](https://github.com/mrdoob/three.js/blob/master/examples/jsm/webxr/VRButton.js).
+
+To add this to your app, simply import the button from three and target your app's renderer. (Elements are globally accessible via their id.)
+
+```js
+import { VRButton } from 'three/examples/jsm/webxr/VRButton.js';
+
+const button = VRButton.createButton(game.renderer);
+document.body.appendChild(button);
+```
+
+You can also create your own XR button with [navigator.xr.requestSession()](https://developer.mozilla.org/en-US/docs/Web/API/XRSystem/requestSession).
+
+```js
+const optionalFeatures = ['local-floor', 'bounded-floor', 'hand-tracking'];
+
+const button = document.createElement('button');
+button.onclick = navigator.xr.requestSession('immersive-vr', { optionalFeatures });
+document.body.appendChild(button);
+```
+
+### Configuring AR
+
+You can configure AR by using three.js's [ARButton](https://github.com/mrdoob/three.js/blob/master/examples/jsm/webxr/ARButton.js) and/or changing [XRSessionMode](https://developer.mozilla.org/en-US/docs/Web/API/XRSessionMode) to `immersive-ar` on custom buttons.
+
+## Events
+
+_TODO_
+
+## Controllers
+
+_TODO_
+
+## Hand-tracking
+
+_TODO_

--- a/src/elements/three-game.ts
+++ b/src/elements/three-game.ts
@@ -40,6 +40,9 @@ export class ThreeGame extends HTMLElement {
     this.renderer.shadowMap.enabled = true
     this.renderer.shadowMap.type = THREE.PCFSoftShadowMap
 
+    /* Configure WebXR */
+    this.renderer.xr.enabled = Boolean(this.hasAttribute('xr'))
+
     /* We'll plug our canvas into the shadow root. */
     const shadow = this.attachShadow({ mode: "open" })
     shadow.appendChild(this.renderer.domElement)

--- a/test/the-basics.test.html
+++ b/test/the-basics.test.html
@@ -1,6 +1,6 @@
 <html>
   <body>
-    <three-game id="game" autorender>
+    <three-game id="game" autorender xr>
       <three-scene id="scene" background-color="#555">
         <three-ambient-light intensity="0.2"></three-ambient-light>
         <three-directional-light
@@ -31,6 +31,12 @@
         describe("three-game autorender attribute", () => {
           it("sets the ThreeGame.autorender property to true", () => {
             expect(game.autorender).to.equal(true)
+          })
+        })
+
+        describe("three-game renderer xr attribute", () => {
+          it("enables WebXR features on ThreeGame.renderer", () => {
+            expect(game.renderer.xr.enabled).to.equal(true)
           })
         })
 


### PR DESCRIPTION
This pull request enables WebXR features whenever the `xr` attribute is present on `<three-game>`. I've expanded the tests to reflect this.

Additionally, I added WebXR to advanced docs, but I can split that into another PR as needed (see #22).