### PR TITLE
Improve ThreeElement Structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 **/node_modules/
 **/*.log
-/dist/
+**/dist/
 /docs/
 **/.vuepress/dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **New:** `<three-game>` now can receive an `xr` attribute to enable WebXR features.
 
+- **New:** The `ThreeElement` class now also provides a `removedCallback` method that will be invoked when we know the element is being _removed_ from the DOM entirely, not just _moved_ to a new parent (as is often the case when pairing three-element with a web application framework.)
+
 - **Changed:** When attributes on an element map to a non-existing property on the wrapped object, there will no longer be a warning logged to the console. (This is very useful when you're combining three-elements with other frameworks that make use of their own attribute names on your elements.)
 
 - **Fixed:** When assigning attributes a value of "0", this will now correctly assign the parsed numerical value of 0 to the corresponding property, not a string representation of it. Programming, how does it work?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **New:** `<three-game>` now can receive an `xr` attribute to enable WebXR features.
 
-- **New:** The `ThreeElement` class now also provides a `removedCallback` method that will be invoked when we know the element is being _removed_ from the DOM entirely, not just _moved_ to a new parent (as is often the case when pairing three-element with a web application framework.)
-
 - **Changed:** When attributes on an element map to a non-existing property on the wrapped object, there will no longer be a warning logged to the console. (This is very useful when you're combining three-elements with other frameworks that make use of their own attribute names on your elements.)
 
 - **Fixed:** When assigning attributes a value of "0", this will now correctly assign the parsed numerical value of 0 to the corresponding property, not a string representation of it. Programming, how does it work?
 
 - **Fixed:** Orthographic cameras now have their frustums and projection matrices updated when the viewport is resized.
+
+### Internals
+
+If you've been extending ThreeElement in your own code, please note the following changes:
+
+- **New:** All element logic that does not deal with managing a wrapped Three.js object has been moved to a new base class called `BaseElement` that `ThreeElement` now extends. `BaseElement` performs lifecycle management, ticker event handling and other base functionality.
+
+- **Breaking Change:** `readyCallback` was renamed to `mountedCallback` to better reflect when this callback is invoked.
+
+- **New:** The `BaseElement` class now also provides a `removedCallback` method that will be invoked when we know the element is being _removed_ from the DOM entirely, not just _moved_ to a new parent (as is often the case when pairing three-element with a web application framework.)
 
 ## [0.2.0] - 2021-01-18
 

--- a/examples/components.html
+++ b/examples/components.html
@@ -23,8 +23,8 @@
 
       importShim("/dist/index.esm.js").then(({ ThreeElement }) => {
         class RotatingThingy extends ThreeElement.for(THREE.Mesh) {
-          readyCallback() {
-            super.readyCallback()
+          mountedCallback() {
+            super.mountedCallback()
 
             this.speed = this.getAttribute("speed")
 

--- a/examples/components.html
+++ b/examples/components.html
@@ -24,6 +24,8 @@
       importShim("/dist/index.esm.js").then(({ ThreeElement }) => {
         class RotatingThingy extends ThreeElement.for(THREE.Mesh) {
           readyCallback() {
+            super.readyCallback()
+
             this.speed = this.getAttribute("speed")
 
             const geometry = document.createElement("three-dodecahedron-buffer-geometry")

--- a/src/BaseElement.ts
+++ b/src/BaseElement.ts
@@ -1,14 +1,11 @@
+import * as THREE from "three"
 import { ThreeGame, TickerFunction } from "./elements/three-game"
 import { ThreeScene } from "./elements/three-scene"
 import { IConstructable } from "./types"
-import { observeAttributeChange } from "./util/observeAttributeChange"
-import * as THREE from "three"
 import { eventForwarder } from "./util/eventForwarder"
+import { observeAttributeChange } from "./util/observeAttributeChange"
 
 export class BaseElement extends HTMLElement {
-  /** Has the element been fully initialized? */
-  isReady = false
-
   /**
    * Returns the instance of ThreeGame that this element is nested under.
    */
@@ -199,8 +196,6 @@ export class BaseElement extends HTMLElement {
 
       /* Emit ready event */
       this.dispatchEvent(new CustomEvent("ready", { bubbles: true, cancelable: false }))
-
-      this.isReady = true
     })
   }
 

--- a/src/BaseElement.ts
+++ b/src/BaseElement.ts
@@ -1,0 +1,150 @@
+import { ThreeElementLifecycleEvent } from "./ThreeElement"
+import { IConstructable } from "./types"
+import { observeAttributeChange } from "./util/observeAttributeChange"
+
+export class BaseElement extends HTMLElement {
+  /** Has the element been fully initialized? */
+  isReady = false
+
+  /** This element's MutationObserver. */
+  private _observer?: MutationObserver
+
+  /**
+   * This callback is invoked when the element is deemed properly initialized. Most
+   * importantly, this happens in a microtask that is very likely executed after all
+   * the other elements in the document have finished running their connectedCallbacks.
+   */
+  readyCallback() {}
+
+  /**
+   * While disconnectedCallback is invoked whenever the element is removed from the DOM
+   * _or_ just moved to a new parent, removedCallback will only be invoked when the
+   * element is actually being removed from the DOM entirely.
+   */
+  removedCallback() {}
+
+  connectedCallback() {
+    this.debug("connectedCallback")
+
+    /* Apply props */
+    const attributes = this.getAllAttributes()
+    for (const key in attributes) {
+      this.attributeChangedCallback(key, "", attributes[key])
+    }
+
+    /*
+    When one of this element's attributes changes, apply it to the object. Custom Elements have a built-in
+    mechanism for this (attributeChangedCallback and observedAttributes, but unfortunately we can't use it,
+    since we don't know the set of attributes the wrapped Three.js classes expose beforehand. So instead
+    we're hacking our way around it using a mutation observer. Fun times!)
+    */
+    this._observer ||= observeAttributeChange(this, (prop, value) => {
+      this.attributeChangedCallback(prop, (this as any)[prop], value)
+    })
+
+    /* Emit connected event */
+    this.dispatchEvent(
+      new ThreeElementLifecycleEvent("connected", { bubbles: true, cancelable: false })
+    )
+
+    /*
+    Some stuff relies on all custom elements being fully defined and connected. However:
+
+    If there are already tags in the DOM, newly created custom elements will connect in the order they
+    are defined, which isn't always what we want (because a Material node that intends to attach itself to
+    a Mesh might be defined before the element that represents that Mesh. Woops!)
+
+    For this reason, we'll run some extra initialization inside a microtask:
+    https://developer.mozilla.org/en-US/docs/Web/API/HTML_DOM_API/Microtask_guide
+    */
+    queueMicrotask(() => {
+      /* Invoke mount method */
+      this.readyCallback()
+
+      /* Emit ready event */
+      this.dispatchEvent(
+        new ThreeElementLifecycleEvent("ready", { bubbles: true, cancelable: false })
+      )
+
+      this.isReady = true
+    })
+  }
+
+  disconnectedCallback() {
+    this.debug("disconnectedCallback")
+
+    /* Emit disconnected event */
+    this.dispatchEvent(
+      new ThreeElementLifecycleEvent("disconnected", { bubbles: true, cancelable: false })
+    )
+
+    /*
+    If isConnected is false, this element is being removed entirely. In this case,
+    we'll do some extra cleanup.
+    */
+    if (!this.isConnected) {
+      queueMicrotask(() => {
+        /* Emit disconnected event */
+        this.dispatchEvent(
+          new ThreeElementLifecycleEvent("removed", { bubbles: true, cancelable: false })
+        )
+
+        /* Invoke removedCallback */
+        this.removedCallback()
+
+        /* Disconnect observer */
+        this._observer?.disconnect()
+        this._observer = undefined
+      })
+    }
+  }
+
+  attributeChangedCallback(key: string, oldValue: string, newValue: string) {}
+
+  /**
+   * Returns a dictionary containing all attributes on this element.
+   */
+  getAllAttributes() {
+    return this.getAttributeNames().reduce((acc, name) => {
+      acc[name] = this.getAttribute(name)
+      return acc
+    }, {} as Record<string, any>)
+  }
+
+  /**
+   * Takes a function, then walks up the node tree and returns the first
+   * node where the function returns true.
+   */
+  find<T extends HTMLElement>(fn: (node: HTMLElement) => any): T | undefined {
+    /* TODO: We might be able to replace this entire function with something like this.closest(). */
+
+    /* Start here */
+    let node: HTMLElement | undefined
+    node = this
+
+    do {
+      /* Get the immediate parent, or, if we're inside a shaodow DOM, the host element */
+      node = node.parentElement || (node.getRootNode() as any).host
+
+      /* Check against the supplied function */
+      if (node && fn(node)) {
+        return node as T
+      }
+    } while (node)
+  }
+
+  /**
+   * Returns this element's tag name, formatted as an actual HTML tag (eg. "<three-mesh>").
+   */
+  get htmlTagName() {
+    return `<${this.tagName.toLowerCase()}>`
+  }
+
+  protected debug(...output: any) {
+    // console.debug(`${this.htmlTagName}`, ...output)
+  }
+
+  protected error(...output: any) {
+    console.error(`${this.htmlTagName}>`, ...output)
+  }
+}

--- a/src/BaseElement.ts
+++ b/src/BaseElement.ts
@@ -149,7 +149,7 @@ export class BaseElement extends HTMLElement {
    * importantly, this happens in a microtask that is very likely executed after all
    * the other elements in the document have finished running their connectedCallbacks.
    */
-  readyCallback() {}
+  mountedCallback() {}
 
   /**
    * While disconnectedCallback is invoked whenever the element is removed from the DOM
@@ -192,7 +192,7 @@ export class BaseElement extends HTMLElement {
     */
     queueMicrotask(() => {
       /* Invoke mount method */
-      this.readyCallback()
+      this.mountedCallback()
 
       /* Emit ready event */
       this.dispatchEvent(new CustomEvent("ready", { bubbles: true, cancelable: false }))

--- a/src/BaseElement.ts
+++ b/src/BaseElement.ts
@@ -1,5 +1,3 @@
-import { ThreeElementLifecycleEvent } from "./ThreeElement"
-import { IConstructable } from "./types"
 import { observeAttributeChange } from "./util/observeAttributeChange"
 
 export class BaseElement extends HTMLElement {
@@ -43,9 +41,7 @@ export class BaseElement extends HTMLElement {
     })
 
     /* Emit connected event */
-    this.dispatchEvent(
-      new ThreeElementLifecycleEvent("connected", { bubbles: true, cancelable: false })
-    )
+    this.dispatchEvent(new CustomEvent("connected", { bubbles: true, cancelable: false }))
 
     /*
     Some stuff relies on all custom elements being fully defined and connected. However:
@@ -62,9 +58,7 @@ export class BaseElement extends HTMLElement {
       this.readyCallback()
 
       /* Emit ready event */
-      this.dispatchEvent(
-        new ThreeElementLifecycleEvent("ready", { bubbles: true, cancelable: false })
-      )
+      this.dispatchEvent(new CustomEvent("ready", { bubbles: true, cancelable: false }))
 
       this.isReady = true
     })
@@ -74,9 +68,7 @@ export class BaseElement extends HTMLElement {
     this.debug("disconnectedCallback")
 
     /* Emit disconnected event */
-    this.dispatchEvent(
-      new ThreeElementLifecycleEvent("disconnected", { bubbles: true, cancelable: false })
-    )
+    this.dispatchEvent(new CustomEvent("disconnected", { bubbles: true, cancelable: false }))
 
     /*
     If isConnected is false, this element is being removed entirely. In this case,
@@ -85,9 +77,7 @@ export class BaseElement extends HTMLElement {
     if (!this.isConnected) {
       queueMicrotask(() => {
         /* Emit disconnected event */
-        this.dispatchEvent(
-          new ThreeElementLifecycleEvent("removed", { bubbles: true, cancelable: false })
-        )
+        this.dispatchEvent(new CustomEvent("removed", { bubbles: true, cancelable: false }))
 
         /* Invoke removedCallback */
         this.removedCallback()

--- a/src/ThreeElement.ts
+++ b/src/ThreeElement.ts
@@ -42,8 +42,8 @@ export class ThreeElement<T = any> extends BaseElement {
     }
   }
 
-  readyCallback() {
-    super.readyCallback()
+  mountedCallback() {
+    super.mountedCallback()
 
     /* Handle attach attribute */
     this.handleAttach()

--- a/src/ThreeElement.ts
+++ b/src/ThreeElement.ts
@@ -157,7 +157,10 @@ export class ThreeElement<T = any> extends HTMLElement {
     }
 
     /* Apply props */
-    this.handleAttributeChange(this.getAllAttributes())
+    const attributes = this.getAllAttributes()
+    for (const key in attributes) {
+      this.attributeChangedCallback(key, null, attributes[key])
+    }
 
     /*
     When one of this element's attributes changes, apply it to the object. Custom Elements have a built-in
@@ -166,7 +169,7 @@ export class ThreeElement<T = any> extends HTMLElement {
     we're hacking our way around it using a mutation observer. Fun times!)
     */
     this._observer = observeAttributeChange(this, (prop, value) => {
-      this.handleAttributeChange({ [prop]: value })
+      this.attributeChangedCallback(prop, this[prop as keyof this], value)
     })
 
     /* Emit connected event */
@@ -392,15 +395,6 @@ export class ThreeElement<T = any> extends HTMLElement {
           }
         }
     }
-  }
-
-  protected handleAttributeChange(attributes: IStringIndexable) {
-    for (const key in attributes) {
-      this.attributeChangedCallback(key, null, attributes[key])
-    }
-
-    /* Make sure a frame is queued */
-    this.game.requestFrame()
   }
 
   protected setCallback(propName: string, fn?: TickerFunction | string) {

--- a/src/ThreeElement.ts
+++ b/src/ThreeElement.ts
@@ -10,10 +10,6 @@ import { observeAttributeChange } from "./util/observeAttributeChange"
 export class ThreeElementLifecycleEvent extends CustomEvent<{}> {}
 
 export class ThreeElement<T = any> extends HTMLElement {
-  static get observedAttributes(): string[] {
-    return []
-  }
-
   /** Has the element been fully initialized? */
   isReady = false
 
@@ -417,21 +413,11 @@ export class ThreeElement<T = any> extends HTMLElement {
       */
       default:
         /*
-        First of all, let's see if we're observing the attribute (as a child class may do.)
-        This is just a cheap way to find out if the class is actually interested in having this
-        property set as an attribute, so we don't randomly just overwrite _any_ property.
+        Okay, at this point, we'll just assume that the property lives on the wrapped object.
+        Good times! Let's assign it directly.
         */
-        if ((this.constructor as any).observedAttributes.includes(key)) {
-          const camelKey = camelize(key)
-          this[camelKey as keyof this] = newValue
-        } else {
-          /*
-          Okay, at this point, we'll just assume that the property lives on the wrapped object.
-          Good times! Let's assign it directly.
-          */
-          if (this.object) {
-            applyProps(this.object, { [key]: newValue })
-          }
+        if (this.object) {
+          applyProps(this.object, { [key]: newValue })
         }
     }
   }

--- a/src/ThreeElement.ts
+++ b/src/ThreeElement.ts
@@ -100,6 +100,21 @@ export class ThreeElement<T = any> extends HTMLElement {
     return game
   }
 
+  /**
+   * Returns the instance of ThreeScene that this element is nested under.
+   */
+  get scene(): ThreeScene {
+    return (this._scene ||= this.findScene())
+  }
+  private _scene?: ThreeScene
+
+  protected findScene() {
+    const scene = this.findElementWith(THREE.Scene) as ThreeScene
+    if (!scene) throw "No <three-scene> tag found!"
+    return scene
+  }
+
+  /** Is this element connected to the game's ticker? */
   get ticking() {
     return this._ticking
   }
@@ -124,18 +139,6 @@ export class ThreeElement<T = any> extends HTMLElement {
   }
   private _forwarder = eventForwarder(this)
   private _ticking = false
-
-  /**
-   * Returns the instance of ThreeScene that this element is nested under.
-   */
-  get scene(): ThreeScene {
-    if (!this._scene) {
-      this._scene = this.findElementWith(THREE.Scene) as ThreeScene
-      if (!this._scene) throw "No <three-scene> tag found!"
-    }
-    return this._scene
-  }
-  private _scene?: ThreeScene
 
   /** This element's MutationObserver. */
   private _observer?: MutationObserver

--- a/src/ThreeElement.ts
+++ b/src/ThreeElement.ts
@@ -159,6 +159,9 @@ export class ThreeElement<T = any> extends HTMLElement {
   connectedCallback() {
     this.debug("connectedCallback")
 
+    /* Construct wrapped object if we don't have on already. */
+    this._object ||= this.constructWrappedObject()
+
     /* Apply props */
     const attributes = this.getAllAttributes()
     for (const key in attributes) {
@@ -171,11 +174,9 @@ export class ThreeElement<T = any> extends HTMLElement {
     since we don't know the set of attributes the wrapped Three.js classes expose beforehand. So instead
     we're hacking our way around it using a mutation observer. Fun times!)
     */
-    if (!this._observer) {
-      this._observer = observeAttributeChange(this, (prop, value) => {
-        this.attributeChangedCallback(prop, this[prop as keyof this], value)
-      })
-    }
+    this._observer ||= observeAttributeChange(this, (prop, value) => {
+      this.attributeChangedCallback(prop, this[prop as keyof this], value)
+    })
 
     /* Emit connected event */
     this.dispatchEvent(

--- a/src/ThreeElement.ts
+++ b/src/ThreeElement.ts
@@ -456,11 +456,11 @@ export class ThreeElement<T = any> extends HTMLElement {
       this.ticking = true
 
       /*
-      We're using setTimeout as a stopgap measure here to accomodate for the fact
-      that the three-game tag may not be available and upgraded at the time this
-      property is set. We'll find a nicer solution for this eventually.
+      We're using queueMicrotask here because at the point when a ticker event
+      property is assigned, it's possible that the elements required to make this
+      work are not done initializing yet.
       */
-      setTimeout(() => {
+      queueMicrotask(() => {
         this.addEventListener(eventName, newCallback)
       })
     }

--- a/src/ThreeElement.ts
+++ b/src/ThreeElement.ts
@@ -287,7 +287,7 @@ export class ThreeElement<T = any> extends HTMLElement {
     this.game.requestFrame()
   }
 
-  private addObjectToScene() {
+  protected addObjectToScene() {
     /*
     If the wrapped object is an Object3D, add it to the scene. If we can find a parent somewhere in the
     tree above it, parent our object to that.
@@ -304,7 +304,7 @@ export class ThreeElement<T = any> extends HTMLElement {
     }
   }
 
-  private handleAttach() {
+  protected handleAttach() {
     /* Use provided attach, or auto-set it based on the tag name. */
     let attach = this.getAttribute("attach")
 
@@ -394,7 +394,7 @@ export class ThreeElement<T = any> extends HTMLElement {
     }
   }
 
-  private handleAttributeChange(attributes: IStringIndexable) {
+  protected handleAttributeChange(attributes: IStringIndexable) {
     for (const key in attributes) {
       this.attributeChangedCallback(key, null, attributes[key])
     }
@@ -403,7 +403,7 @@ export class ThreeElement<T = any> extends HTMLElement {
     this.game.requestFrame()
   }
 
-  private setCallback(propName: string, fn?: TickerFunction | string) {
+  protected setCallback(propName: string, fn?: TickerFunction | string) {
     const eventName = propName.replace(/^on/, "") as any
 
     /* Unregister previous callback */
@@ -443,11 +443,11 @@ export class ThreeElement<T = any> extends HTMLElement {
     }
   }
 
-  private debug(...output: any) {
+  protected debug(...output: any) {
     // console.debug(`${this.htmlTagName}`, ...output)
   }
 
-  private error(...output: any) {
+  protected error(...output: any) {
     console.error(`${this.htmlTagName}>`, ...output)
   }
 

--- a/src/ThreeElement.ts
+++ b/src/ThreeElement.ts
@@ -259,7 +259,7 @@ export class ThreeElement<T = any> extends HTMLElement {
    * Takes a function, then walks up the node tree and returns the first
    * node where the function returns true.
    */
-  find<T extends HTMLElement>(fn: (node: HTMLElement) => any) {
+  find<T extends HTMLElement>(fn: (node: HTMLElement) => any): T | undefined {
     /* TODO: We might be able to replace this entire function with something like this.closest(). */
 
     /* Start here */
@@ -272,7 +272,7 @@ export class ThreeElement<T = any> extends HTMLElement {
 
       /* Check against the supplied function */
       if (node && fn(node)) {
-        return node
+        return node as T
       }
     } while (node)
   }

--- a/src/ThreeElement.ts
+++ b/src/ThreeElement.ts
@@ -5,9 +5,6 @@ import { ThreeScene } from "./elements/three-scene"
 import { IConstructable, isDisposable } from "./types"
 import { applyProps } from "./util/applyProps"
 import { eventForwarder } from "./util/eventForwarder"
-import { observeAttributeChange } from "./util/observeAttributeChange"
-
-export class ThreeElementLifecycleEvent extends CustomEvent<{}> {}
 
 export class ThreeElement<T = any> extends BaseElement {
   /** Has the element been fully initialized? */

--- a/src/ThreeElement.ts
+++ b/src/ThreeElement.ts
@@ -189,15 +189,10 @@ export class ThreeElement<T = any> extends HTMLElement {
     are defined, which isn't always what we want (because a Material node that intends to attach itself to
     a Mesh might be defined before the element that represents that Mesh. Woops!)
 
-    For this reason, we'll use a simple trick -- we will wait with the actual mounting until another tick
-    has passed, by way of setTimeout.
-
-    Yeah, I know. Crazy. But it solves the problem elegantly. Except that classes overloading
-    connectedCallback() will need to remember doing this. But maybe we will find a better way in the future.
-
-    Also see: https://javascript.info/custom-elements#rendering-order
+    For this reason, we'll run some extra initialization inside a microtask:
+    https://developer.mozilla.org/en-US/docs/Web/API/HTML_DOM_API/Microtask_guide
     */
-    setTimeout(() => {
+    queueMicrotask(() => {
       /* Handle attach attribute */
       this.handleAttach()
 
@@ -221,8 +216,18 @@ export class ThreeElement<T = any> extends HTMLElement {
     })
   }
 
+  /**
+   * This callback is invoked when the element is deemed properly initialized. Most
+   * importantly, this happens in a microtask that is very likely executed after all
+   * the other elements in the document have finished running their connectedCallbacks.
+   */
   readyCallback() {}
 
+  /**
+   * While disconnectedCallback is invoked whenever the element is removed from the DOM
+   * _or_ just moved to a new parent, removedCallback will only be invoked when the
+   * element is actually being removed from the DOM entirely.
+   */
   removedCallback() {}
 
   disconnectedCallback() {

--- a/src/ThreeElement.ts
+++ b/src/ThreeElement.ts
@@ -1,7 +1,7 @@
 import * as THREE from "three"
 import { ThreeGame, TickerFunction } from "./elements/three-game"
 import { ThreeScene } from "./elements/three-scene"
-import { IConstructable, isDisposable, IStringIndexable } from "./types"
+import { IConstructable, isDisposable } from "./types"
 import { applyProps } from "./util/applyProps"
 import { camelize } from "./util/camelize"
 import { eventForwarder } from "./util/eventForwarder"

--- a/src/ThreeElement.ts
+++ b/src/ThreeElement.ts
@@ -238,40 +238,42 @@ export class ThreeElement<T = any> extends HTMLElement {
       new ThreeElementLifecycleEvent("disconnected", { bubbles: true, cancelable: false })
     )
 
-    /* Queue a frame, because very likely something just changed in the scene :) */
-    this.game.requestFrame()
-
     /*
     If isConnected is false, this element is being removed entirely. In this case,
     we'll do some extra cleanup.
     */
     if (!this.isConnected) {
-      /* Emit disconnected event */
-      this.dispatchEvent(
-        new ThreeElementLifecycleEvent("removed", { bubbles: true, cancelable: false })
-      )
+      queueMicrotask(() => {
+        /* Emit disconnected event */
+        this.dispatchEvent(
+          new ThreeElementLifecycleEvent("removed", { bubbles: true, cancelable: false })
+        )
 
-      /* Invoke removedCallback */
-      this.removedCallback()
+        /* Invoke removedCallback */
+        this.removedCallback()
 
-      /* Disconnect observer */
-      this._observer?.disconnect()
-      this._observer = undefined
+        /* Queue a frame, because very likely something just changed in the scene :) */
+        this.game.requestFrame()
 
-      /* Stop listening to the game's ticker events */
-      this.ticking = false
+        /* Disconnect observer */
+        this._observer?.disconnect()
+        this._observer = undefined
 
-      /* If the wrapped object is parented, remove it from its parent */
-      if (this.object instanceof THREE.Object3D && this.object.parent) {
-        this.debug("Removing from scene:", this.object)
-        this.object.parent.remove(this.object)
-      }
+        /* Stop listening to the game's ticker events */
+        this.ticking = false
 
-      /* If the object can be disposed, dispose of it! */
-      if (isDisposable(this.object)) {
-        this.debug("Disposing:", this.object)
-        this.object.dispose()
-      }
+        /* If the wrapped object is parented, remove it from its parent */
+        if (this.object instanceof THREE.Object3D && this.object.parent) {
+          this.debug("Removing from scene:", this.object)
+          this.object.parent.remove(this.object)
+        }
+
+        /* If the object can be disposed, dispose of it! */
+        if (isDisposable(this.object)) {
+          this.debug("Disposing:", this.object)
+          this.object.dispose()
+        }
+      })
     }
   }
 

--- a/src/ThreeElement.ts
+++ b/src/ThreeElement.ts
@@ -1,15 +1,9 @@
 import * as THREE from "three"
 import { BaseElement } from "./BaseElement"
-import { ThreeGame, TickerFunction } from "./elements/three-game"
-import { ThreeScene } from "./elements/three-scene"
 import { IConstructable, isDisposable } from "./types"
 import { applyProps } from "./util/applyProps"
-import { eventForwarder } from "./util/eventForwarder"
 
 export class ThreeElement<T = any> extends BaseElement {
-  /** Has the element been fully initialized? */
-  isReady = false
-
   /** Constructor that will instantiate our object. */
   static threeConstructor?: IConstructable
 

--- a/src/ThreeElement.ts
+++ b/src/ThreeElement.ts
@@ -90,13 +90,15 @@ export class ThreeElement<T = any> extends HTMLElement {
    * Returns the instance of ThreeGame that this element is nested under.
    */
   get game(): ThreeGame {
-    if (!this._game) {
-      this._game = this.find((node) => node instanceof ThreeGame) as ThreeGame
-      if (!this._game) throw "No <three-game> tag found!"
-    }
-    return this._game
+    return (this._game ||= this.findGame())
   }
   private _game?: ThreeGame
+
+  protected findGame() {
+    const game = this.find((node) => node instanceof ThreeGame) as ThreeGame
+    if (!game) throw "No <three-game> tag found!"
+    return game
+  }
 
   get ticking() {
     return this._ticking

--- a/src/ThreeElement.ts
+++ b/src/ThreeElement.ts
@@ -21,26 +21,27 @@ export class ThreeElement<T = any> extends HTMLElement {
   static threeConstructor?: IConstructable
 
   /** The THREE.* object managed by this element. */
+  get object() {
+    return (this._object ||= this.constructWrappedObject())
+  }
+
   private _object?: T
 
-  get object() {
+  protected constructWrappedObject() {
     const constructor = (this.constructor as typeof ThreeElement).threeConstructor
 
-    if (!this._object && constructor) {
-      this.debug("object accessed for the first time, let's create the damn thing!")
+    if (constructor) {
+      this.debug("Creating wrapped object instance")
 
       /* Create managed object */
       const args = this.getAttribute("args")
       if (args) {
         const parsed = JSON.parse(args)
-        this._object = new constructor(...(Array.isArray(parsed) ? parsed : [parsed]))
+        return new constructor(...(Array.isArray(parsed) ? parsed : [parsed]))
       } else {
-        this._object = new constructor()
+        return new constructor()
       }
     }
-
-    /* Return it */
-    return this._object
   }
 
   /**

--- a/src/ThreeElement.ts
+++ b/src/ThreeElement.ts
@@ -22,6 +22,9 @@ export class ThreeElement<T = any> extends HTMLElement {
 
   /** The THREE.* object managed by this element. */
   get object() {
+    if (!this.isConnected)
+      throw "Something is accessing my .game property while I'm not connected. This shouldn't happen! 😭"
+
     return (this._object ||= this.constructWrappedObject())
   }
 
@@ -98,6 +101,9 @@ export class ThreeElement<T = any> extends HTMLElement {
    * Returns the instance of ThreeGame that this element is nested under.
    */
   get game(): ThreeGame {
+    if (!this.isConnected)
+      throw "Something is accessing my .game property while I'm not connected. This shouldn't happen! 😭"
+
     return (this._game ||= this.findGame())
   }
   private _game?: ThreeGame
@@ -112,6 +118,9 @@ export class ThreeElement<T = any> extends HTMLElement {
    * Returns the instance of ThreeScene that this element is nested under.
    */
   get scene(): ThreeScene {
+    if (!this.isConnected)
+      throw "Something is accessing my .scene property while I'm not connected. This shouldn't happen! 😭"
+
     return (this._scene ||= this.findScene())
   }
   private _scene?: ThreeScene

--- a/src/elements/three-gltf-asset.ts
+++ b/src/elements/three-gltf-asset.ts
@@ -6,10 +6,6 @@ import { registerElement } from "../util/registerElement"
 const loadedUrls: Record<string, GLTF> = {}
 
 export class ThreeGLTFAsset extends ThreeElement.for(Group) {
-  static get observedAttributes() {
-    return [...ThreeElement.observedAttributes, "url"]
-  }
-
   public get url() {
     return this.getAttribute("url")
   }
@@ -25,6 +21,16 @@ export class ThreeGLTFAsset extends ThreeElement.for(Group) {
           this.setupGLTF(gltf)
         })
       }
+    }
+  }
+
+  attributeChangedCallback(name: string, oldValue: string, newValue: string) {
+    switch (name) {
+      case "url":
+        this.url = newValue
+        return
+      default:
+        super.attributeChangedCallback(name, oldValue, newValue)
     }
   }
 

--- a/src/elements/three-gltf-asset.ts
+++ b/src/elements/three-gltf-asset.ts
@@ -28,9 +28,9 @@ export class ThreeGLTFAsset extends ThreeElement.for(Group) {
     switch (name) {
       case "url":
         this.url = newValue
-        return
+        return true
       default:
-        super.attributeChangedCallback(name, oldValue, newValue)
+        return super.attributeChangedCallback(name, oldValue, newValue)
     }
   }
 

--- a/src/elements/three-orbit-controls.ts
+++ b/src/elements/three-orbit-controls.ts
@@ -5,7 +5,7 @@ import { registerElement } from "../util/registerElement"
 export class ThreeOrbitControls extends ThreeElement<OrbitControls> {
   controls?: OrbitControls
 
-  readyCallback() {
+  mountedCallback() {
     const { renderer } = this.game
     let { camera } = this.scene
     this.controls = new OrbitControls(camera, renderer.domElement)

--- a/src/elements/three-orbit-controls.ts
+++ b/src/elements/three-orbit-controls.ts
@@ -31,9 +31,9 @@ export class ThreeOrbitControls extends ThreeElement<OrbitControls> {
     })
   }
 
-  disconnectedCallback() {
+  removedCallback() {
     this.controls?.dispose()
-    super.disconnectedCallback()
+    super.removedCallback()
   }
 }
 

--- a/src/elements/three-scene.ts
+++ b/src/elements/three-scene.ts
@@ -77,7 +77,7 @@ export class ThreeScene extends ThreeElement.for(Scene) {
         return
 
       case "camera":
-        setTimeout(() => {
+        queueMicrotask(() => {
           const el = document.getElementById(newValue) as ThreeElement<Camera>
 
           if (!el) {

--- a/src/elements/three-scene.ts
+++ b/src/elements/three-scene.ts
@@ -64,6 +64,8 @@ export class ThreeScene extends ThreeElement.for(Scene) {
     /* Unregister event handlers */
     this.game.removeEventListener("rendertick", this.render)
     window.removeEventListener("resize", this.handleWindowResize)
+
+    super.disconnectedCallback()
   }
 
   attributeChangedCallback(name: string, oldValue: string, newValue: string) {

--- a/src/elements/three-scene.ts
+++ b/src/elements/three-scene.ts
@@ -36,7 +36,7 @@ export class ThreeScene extends ThreeElement.for(Scene) {
     this.camera.lookAt(0, 0, 0)
   }
 
-  readyCallback() {
+  mountedCallback() {
     /* Set up event processor */
     this.pointer = new PointerEvents(this.game.renderer, this.object!, this.camera)
 

--- a/src/elements/three-scene.ts
+++ b/src/elements/three-scene.ts
@@ -4,10 +4,6 @@ import { ThreeElement } from "../ThreeElement"
 import { registerElement } from "../util/registerElement"
 
 export class ThreeScene extends ThreeElement.for(Scene) {
-  static get observedAttributes() {
-    return ["background-color", "camera"]
-  }
-
   /** The current camera that is being used to render the scene. */
   private _camera: Camera = new PerspectiveCamera(
     75,

--- a/src/elements/three-scene.ts
+++ b/src/elements/three-scene.ts
@@ -72,7 +72,7 @@ export class ThreeScene extends ThreeElement.for(Scene) {
     switch (name) {
       case "background-color":
         this.object!.background = new Color(newValue)
-        return
+        return true
 
       case "camera":
         queueMicrotask(() => {
@@ -87,10 +87,10 @@ export class ThreeScene extends ThreeElement.for(Scene) {
             this.camera.lookAt(0, 0, 0)
           }
         })
-        return
+        return true
     }
 
-    super.attributeChangedCallback(name, oldValue, newValue)
+    return super.attributeChangedCallback(name, oldValue, newValue)
   }
 
   handleWindowResize() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { IConstructable } from "./types"
 import { dasherize } from "./util/dasherize"
 import { registerElement } from "./util/registerElement"
 export * from "./elements"
+export { BaseElement } from "./BaseElement"
 export { registerElement, ThreeElement }
 
 const banner = () =>

--- a/src/util/applyProps.ts
+++ b/src/util/applyProps.ts
@@ -65,6 +65,10 @@ export const applyProps = (object: IStringIndexable, props: IStringIndexable) =>
         break
 
       default:
+        /*
+        If we've reached this point, we're finally able to set a property on the object.
+        Amazing! But let's only do it if the property key is actually known.
+        */
         if (key in object) object[key] = parsed !== undefined ? parsed : value
     }
   }


### PR DESCRIPTION
I'm working on some small to medium refactorings to make things less surprising.

Checklist/notes:

- [x] Remove `handleChangedAttributes`, it's mostly useless
- [x] Implement a `removedCallback`
- [x] Extract the non-Three-specific bits to a separate base class that we can a) use in ThreeGame et al, and b) export so our users can use it too (for stuff that needs ticking and lifecycle callbacks, but doesn't wrap an object)
  - [x] Move callbacks
  - [x] Move observer
  - [x] Move ticker event handling
  - [x] Move ticking property
  - [x] Move logging helpers
  - [x] Rename/move ThreeElementLifecycleEvent
  - [x] Resolve circular dependency
- [x] Maybe `readyCallback` -> `mountedCallback` ("mounted" is a bit more descriptive than "read")
- [x] Remove `isReady` property? Do we really need it?
- [x] Try, once again, to explicitly create wrapped object, set game, and set scene, in connectedCallback. We only pull these lazily because sometimes we're assigning attributes before the element is connected, but that shouldn't really happen, so we should look into that instead.
- [ ] Provide a more realistic lit-html demo