### PR TITLE
Expanded parser for advanced input

### DIFF
--- a/src/util/applyProps.ts
+++ b/src/util/applyProps.ts
@@ -1,5 +1,29 @@
 import { IStringIndexable } from "../types"
+import { MathUtils } from "three"
 import { camelize } from "./camelize"
+
+// Uses an ancient ritual language to check for degrees
+const DEGREES_REGEX = /deg\((.*?)\)/g
+
+/**
+ * Parses and handles conversions for float props
+ */
+export const parseProps = (str: string) => {
+  // Checks if props use modifiers, otherwise early return as float
+  const needsConversion = DEGREES_REGEX.test(str)
+  if (!needsConversion) return parseFloat(str)
+
+  // Isolate modified props
+  const groups = str.match(DEGREES_REGEX)
+
+  // Handle degrees modifiers
+  const radians = groups?.map((g: string) =>
+    MathUtils.degToRad(parseFloat(g.replace(/(deg\(|\))/, "")))
+  )
+
+  // Finally, return the parsed props as radians
+  return radians?.length === 1 ? radians[0] : radians
+}
 
 const IGNORED_KEYS = ["id"]
 

--- a/src/util/applyProps.ts
+++ b/src/util/applyProps.ts
@@ -9,20 +9,25 @@ const DEGREES_REGEX = /deg\((.*?)\)/g
  * Parses and handles conversions for float props
  */
 export const parseProps = (str: string) => {
-  // Checks if props use modifiers, otherwise early return as float
+  const isNumber = !isNaN(parseFloat(str))
   const needsConversion = DEGREES_REGEX.test(str)
+
+  // Ignore non-integers without modifiers
+  if (!isNumber && !needsConversion) return str
+
+  // Skip to parsing for non-modified props
   if (!needsConversion) return parseFloat(str)
 
   // Isolate modified props
-  const groups = str.match(DEGREES_REGEX)
+  const prop = str.match(DEGREES_REGEX)
 
   // Handle degrees modifiers
-  const radians = groups?.map((g: string) =>
-    MathUtils.degToRad(parseFloat(g.replace(/(deg\(|\))/, "")))
-  )
+  const radians = prop
+    ?.map((g: string) => MathUtils.degToRad(parseFloat(g.replace(/(deg\(|\))/, ""))))
+    .shift()
 
   // Finally, return the parsed props as radians
-  return radians?.length === 1 ? radians[0] : radians
+  return radians
 }
 
 const IGNORED_KEYS = ["id"]

--- a/test/util/applyProps.test.ts
+++ b/test/util/applyProps.test.ts
@@ -2,21 +2,19 @@ import { expect } from "@open-wc/testing"
 import { parseProps, applyProps } from "../../src/util/applyProps"
 
 describe("parseProps", () => {
+  it("leaves strings alone", () => {
+    const string = parseProps("String")
+    expect(string).to.equal("String")
+  })
+
   it("can parse radians to floats", () => {
-    const props = parseProps("3.14")
-    expect(props).to.equal(3.14)
+    const radians = parseProps("3.14")
+    expect(radians).to.equal(3.14)
   })
 
-  it("can parse deg(180) to Pi radians", () => {
-    const prop = parseProps("deg(180)")
-    expect(prop).to.equal(Math.PI)
-  })
-
-  it("can parse [deg(180), deg(20), deg(-20)] to radians", () => {
-    const [x, y, z] = parseProps("[deg(180), deg(20), deg(-20)]") as Number[]
-    expect(x).to.equal(Math.PI)
-    expect(y).to.equal(Math.PI / 9)
-    expect(z).to.equal(-Math.PI / 9)
+  it("can parse deg(180) to π radians", () => {
+    const degrees = parseProps("deg(180)")
+    expect(degrees).to.equal(Math.PI)
   })
 })
 

--- a/test/util/applyProps.test.ts
+++ b/test/util/applyProps.test.ts
@@ -1,5 +1,24 @@
 import { expect } from "@open-wc/testing"
-import { applyProps } from "../../src/util/applyProps"
+import { parseProps, applyProps } from "../../src/util/applyProps"
+
+describe("parseProps", () => {
+  it("can parse radians to floats", () => {
+    const props = parseProps("3.14")
+    expect(props).to.equal(3.14)
+  })
+
+  it("can parse deg(180) to Pi radians", () => {
+    const prop = parseProps("deg(180)")
+    expect(prop).to.equal(Math.PI)
+  })
+
+  it("can parse [deg(180), deg(20), deg(-20)] to radians", () => {
+    const [x, y, z] = parseProps("[deg(180), deg(20), deg(-20)]") as Number[]
+    expect(x).to.equal(Math.PI)
+    expect(y).to.equal(Math.PI / 9)
+    expect(z).to.equal(-Math.PI / 9)
+  })
+})
 
 describe("applyProps", () => {
   it("can directly assign root-level properties", () => {


### PR DESCRIPTION
This pull request expands on #31 by creating a new `parseProps` method in [`src/utils/applyProps.ts`](https://github.com/CodyJasonBennett/three-elements/blob/support-degrees/src/util/applyProps.ts#L5-L31) that expands on parsing floats and introducing conversions with modifiers like `deg(180)` to specify 180 degrees or π radians.

You can play around with this in the updated tests.

I have not yet applied this to the internal `applyProps` method as I'm unsure of the exact implementation, as this is a recent development.