### PR TITLE
EXPERIMENT: Reflect object properties on the element itself

### DIFF
--- a/src/ThreeElement.ts
+++ b/src/ThreeElement.ts
@@ -35,6 +35,34 @@ export class ThreeElement<T = any> extends BaseElement {
         object.userData.threeElement = this
       }
 
+      /*
+      EXPERIMENT ALERT! 💥
+
+      We're going to reflect all of the object's properties that are not functions
+      as properties on this element. This would allow us to achieve parity between
+      properties and attributes of elements. BUT AT WHAT COST?! 🤔
+      */
+      for (const prop in object) {
+        if (!(prop in this) && typeof object[prop] !== "function") {
+          /*
+          We'll define the property directly on this class' prototype. Will it
+          work? Who knows! It looks like it does! I have no idea what I'm doing!
+          But we'll use functions for the getters and the setters because those
+          will actually run in the individual instance's scope. Thanks to purely
+          accidental cool, this *should* mean that we're only ever registering
+          these properties once per ThreeElement-derived class. Aaaaaaaaahhhh
+          */
+          Object.defineProperty(this.constructor.prototype, prop, {
+            get: function () {
+              return this.object[prop]
+            },
+            set: function (v: any) {
+              this.object[prop] = v
+            }
+          })
+        }
+      }
+
       return object
     }
   }


### PR DESCRIPTION
Things are getting a bit crazy now, but it SEEMS to work? Anyone feel like weighing in?

**Things this would allows us to do:**

- Achieve (almost) parity between the _attributes_ and _properties_ of an element. You could do `<three-mesh position.x="5">` just like you could do `meshElement.position.x = 5`.
- Very likely significantly simplify our attribute handling code.

**Potential problems:**

- this makes us much more dependent on changes in Three.js itself. If Three.js ever introduces a property named, say, `mountedCallback`, it would break our entire setup because we couldn't possibly reflect that property on elements (because they already have a `mountedCallback`.) You could argue that the chances that Three.js will ever have a `mountedCallback` are extremely slim, but this was just an example -- it will generally apply to all properties that may already exist on HTMLElements and classes derived from it (like the ones we provide.)

I don't intend to merge this change any time soon -- just wanted to put it out there for discussion.