### PR TITLE
New `observed` flag to enable global MutationObserver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
       - name: Install dependencies
         run: yarn install
 
+      - name: Bootstrap Lerna
+        run: yarn lerna bootstrap
+
       - name: Build package
         run: yarn build
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.4.0] - unreleased
 
+- **New:** You can now set the `observed` attribute on the `<three-game>` tag to make it monitor changed attributes using a MutationObserver. This is useful if you want to edit the DOM of a project directly in your browser's devtools; other than that, it serves no real purpose. Please keep in mind that enabling this flag has a very high performance cost; for this reason, we're also making it log a warning when enabled.
+
 - **New:** We now provide a `@three-elements/preact` package that provides some light-weight bindings for use in Preact applications using its hyperscript syntax. This makes use of an experimental new proxy generator (housed in the equally new `@three-elements/proxy` package) that can be used to create three-elements bindings for all sorts of web frameworks, so expect to see more of this in the future.
 
 - **Breaking Change:** `<three-web-gl-renderer>` now is `<three-webgl-renderer>`.

--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -50,11 +50,11 @@
     "preact": "^10.5.12"
   },
   "dependencies": {
-    "@three-elements/proxy": "^0.3.1-alpha.0"
+    "@three-elements/proxy": "^0.4.0-alpha.1"
   },
   "peerDependencies": {
     "preact": ">=10.0.0",
-    "three-elements": "^0.3.1-alpha.0"
+    "three-elements": "^0.4.0-alpha.1"
   },
   "gitHead": "c3f0dd533ca26538b691b7ff6f5a7548f3512c36"
 }

--- a/packages/three-elements/src/BaseElement.ts
+++ b/packages/three-elements/src/BaseElement.ts
@@ -94,7 +94,7 @@ export class BaseElement extends HTMLElement {
    * are exposing.)
    */
   setAttribute(name: string, value: string) {
-    this.attributeChangedCallback(name, this.getAttribute(name)!, value)
+    this.attributeChangedCallback(name, this.getAttribute(name), value)
     super.setAttribute(name, value)
   }
 
@@ -168,7 +168,7 @@ export class BaseElement extends HTMLElement {
     }
   }
 
-  attributeChangedCallback(key: string, _: string, value: string): boolean {
+  attributeChangedCallback(key: string, _: string | null, value: string): boolean {
     this.debug("attributeChangedCallback", key, value)
 
     switch (key) {

--- a/packages/three-elements/src/elements/three-game.ts
+++ b/packages/three-elements/src/elements/three-game.ts
@@ -12,7 +12,7 @@ export class ThreeGame extends HTMLElement {
 
   emitter = new EventEmitter()
 
-  /* OBSERVER */
+  /* OPT-IN OBSERVER */
 
   /**
    * ThreeGame optionally allows the user to request it to use a MutationObserver

--- a/packages/three-elements/src/elements/three-game.ts
+++ b/packages/three-elements/src/elements/three-game.ts
@@ -50,6 +50,10 @@ export class ThreeGame extends HTMLElement {
     this.observer.disconnect()
 
     if (this._observed) {
+      console.warn(
+        "WARNING: You have enabled the `observed` attribute. This feature is intended for development only and should not be enabled in production projects, as it has a significant impact on performance."
+      )
+
       this.observer.observe(this, {
         attributes: true,
         attributeOldValue: false,
@@ -107,9 +111,6 @@ export class ThreeGame extends HTMLElement {
 
     /* Initialize renderer size */
     this.setupRenderer()
-
-    /* Start observing, if requested */
-    this.observed = this.hasAttribute("observed")
 
     /* Look out for some specific stuff connecting within our branch of the document */
     this.addEventListener("connected", (e) => {

--- a/packages/three-elements/test/three-game-observed.test.ts
+++ b/packages/three-elements/test/three-game-observed.test.ts
@@ -1,0 +1,17 @@
+import { expect, fixture, html } from "@open-wc/testing"
+import "../src"
+import { ThreeGame } from "../src/elements/three-game"
+
+describe("<three-game observed>", () => {
+  const render = (): Promise<ThreeGame> =>
+    fixture(
+      html`
+        <three-game observed></three-game>
+      `
+    )
+
+  it("activates the game's observer", async () => {
+    const game = (await render()) as ThreeGame
+    expect(game.observed).to.be.true
+  })
+})


### PR DESCRIPTION
- Introduces a new `observed` attribute on `<three-game>`
- When enabled, the game will launch an extra MutationObserver to monitor attribute changes anywhere within its DOM.
- A warning is logged to remind the user that this is intended for development only, and should not be used in production projects because of the detrimental performance implications of using said MutationObserver.
- The test is a bit basic, but there isn't much we can realistically test, since this only kicks in when an actual human changes an attribute in their devtools.

Will fix #44 when merged.