### PR TITLE
Align property & attribute assignments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **New: Experimental Preact Bindings!** We now provide a `@three-elements/preact` package that provides some light-weight bindings for use in Preact applications using its hyperscript syntax. This makes use of an experimental new proxy generator (housed in the equally new `@three-elements/proxy` package) that can be used to create three-elements bindings for all sorts of web frameworks, so expect to see more of this in the future.
 
+- **Breaking Change:** When referencing the objects managed by other elements -- like a custom camera, or a geometry or material you want to reuse across multiple meshes -- you now have to prefix the attribute with the new `ref:` directive:
+
+  ```html
+  <three-mesh ref:geometry="#my-geometry" ref:material="#my-material"></three-mesh>
+  ```
+
 - **Breaking Change:** `<three-web-gl-renderer>` now is `<three-webgl-renderer>`.
 
 - **Fixed:** When switching a scene to a new camera, this new camera would not be picked up by the scene's pointer event manager, pretty much breaking pointer interactions for the entire scene. This has now been resolved.

--- a/packages/examples/public/attribute-mutation-performance.html
+++ b/packages/examples/public/attribute-mutation-performance.html
@@ -63,13 +63,15 @@
         const y = Math.sin(t / 300) * 5 * f + Math.cos((t / 4000) * 3)
         const z = Math.cos((t + 200) / 400) * 3
 
-        return html`<three-mesh
-          position.x=${x}
-          position.y=${y}
-          position.z=${z}
-          geometry="#geometry"
-          material="#material"
-        ></three-mesh>`
+        return html`
+          <three-mesh
+            position.x=${x}
+            position.y=${y}
+            position.z=${z}
+            ref:geometry="#geometry"
+            ref:material="#material"
+          ></three-mesh>
+        `
       }
 
       const Swarm = (count = 10) => {

--- a/packages/examples/public/custom-camera.html
+++ b/packages/examples/public/custom-camera.html
@@ -10,7 +10,7 @@
   </head>
   <body>
     <three-game autorender>
-      <three-scene background-color="#c88" camera=".active">
+      <three-scene background-color="#c88" ref:camera=".active">
         <!-- This camera will replace the one that's automatically provided by the scene itself. -->
         <three-perspective-camera class="active" position="5, 5, 50"></three-perspective-camera>
 

--- a/packages/examples/public/index.html
+++ b/packages/examples/public/index.html
@@ -20,7 +20,7 @@
         <li><a href="gltf.html">GLTF Loading</a></li>
         <li><a href="multiple.html">Multiple Canvases</a></li>
         <li><a href="pointer-events.html">Pointer Events</a></li>
-        <li><a href="reusing-resources.html">Reusing Resources</a></li>
+        <li><a href="references.html">References</a></li>
         <li><a href="static.html">Static HTML</a></li>
         <li><a href="templates.html">Template Tags</a></li>
         <li><a href="text.html">Text</a></li>

--- a/packages/examples/public/rect-area-lights.html
+++ b/packages/examples/public/rect-area-lights.html
@@ -28,9 +28,9 @@
         <area-light id="light2" position="0, 5, 5" color="green"></area-light>
         <area-light id="light3" position="5, 5, 5" color="blue"></area-light>
 
-        <three-rect-area-light-helper light="#light1"></three-rect-area-light-helper>
-        <three-rect-area-light-helper light="#light2"></three-rect-area-light-helper>
-        <three-rect-area-light-helper light="#light3"></three-rect-area-light-helper>
+        <three-rect-area-light-helper ref:light="#light1"></three-rect-area-light-helper>
+        <three-rect-area-light-helper ref:light="#light2"></three-rect-area-light-helper>
+        <three-rect-area-light-helper ref:light="#light3"></three-rect-area-light-helper>
 
         <!-- torus knot -->
         <three-mesh position.y="5" tick="object.rotation.y = performance.now() / 1000">

--- a/packages/examples/public/rect-area-lights.html
+++ b/packages/examples/public/rect-area-lights.html
@@ -11,7 +11,7 @@
 
   <body>
     <three-game id="game" autorender>
-      <three-scene camera=".active">
+      <three-scene ref:camera=".active">
         <!-- camera -->
         <three-perspective-camera
           class="active"

--- a/packages/examples/public/references.html
+++ b/packages/examples/public/references.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Reusing Materials and Geometires</title>
+    <title>References</title>
     <link rel="stylesheet" href="styles.css" />
     <meta
       name="viewport"

--- a/packages/examples/public/reusing-resources.html
+++ b/packages/examples/public/reusing-resources.html
@@ -27,34 +27,34 @@
         <!-- Scene Contents -->
         <three-group tick="object.rotateX(0.1 * dt); object.rotateY(0.2 * dt)">
           <three-mesh
-            geometry="#geometry"
-            material="#material"
+            ref:geometry="#geometry"
+            ref:material="#material"
             position="-3.5, 0, 0"
             scale="0.7"
             tick="object.rotation.x = object.rotation.y += 3 * dt"
           ></three-mesh>
           <three-mesh
             position="-2, 0, 0"
-            geometry="#geometry"
-            material="#material"
+            ref:geometry="#geometry"
+            ref:material="#material"
             tick="object.rotation.x = object.rotation.y += 1.5 * dt"
           ></three-mesh>
           <three-mesh
             position="0, 0, 0"
-            geometry="#geometry"
-            material="#material"
+            ref:geometry="#geometry"
+            ref:material="#material"
             scale="1.5"
           ></three-mesh>
           <three-mesh
             position="2, 0, 0"
-            geometry="#geometry"
-            material="#material"
+            ref:geometry="#geometry"
+            ref:material="#material"
             tick="object.rotation.x = object.rotation.y -= 1.5 * dt"
           ></three-mesh>
           <three-mesh
             position="3.5, 0, 0"
-            geometry="#geometry"
-            material="#material"
+            ref:geometry="#geometry"
+            ref:material="#material"
             scale="0.7"
             tick="object.rotation.x = object.rotation.y -= 3 * dt"
           ></three-mesh>

--- a/packages/examples/public/with-preact.html
+++ b/packages/examples/public/with-preact.html
@@ -15,8 +15,8 @@
     <!-- Import dependencies via ESM. The future is now! -->
     <script type="module">
       import "three-elements"
-      import { h, Component, render } from "https://jspm.dev/preact"
-      import { useRef, useEffect } from "https://jspm.dev/preact/hooks"
+      import { h, Component, render } from "preact"
+      import { useRef, useEffect } from "preact/hooks"
 
       import { T } from "@three-elements/preact"
 
@@ -84,7 +84,7 @@
       const Camera = () => T.PerspectiveCamera({ id: "camera", fov: 70, position: [0, 0, 30] })
 
       const Scene = () =>
-        T.Scene({ camera: "#camera", "background-color": "#222" }, [
+        T.Scene({ camera: "#camera", backgroundColor: "#222" }, [
           h(Resources),
           h(Fog),
           h(Camera),

--- a/packages/examples/public/with-preact.html
+++ b/packages/examples/public/with-preact.html
@@ -39,8 +39,8 @@
       const Cube = (props) =>
         T.Mesh({
           ...props,
-          geometry: "#geometry",
-          material: "#material",
+          "ref:geometry": "#geometry",
+          "ref:material": "#material",
           tick: (dt, { object }) => {
             /* Time */
             const t =
@@ -84,7 +84,7 @@
       const Camera = () => T.PerspectiveCamera({ id: "camera", fov: 70, position: [0, 0, 30] })
 
       const Scene = () =>
-        T.Scene({ camera: "#camera", backgroundColor: "#222" }, [
+        T.Scene({ "ref:camera": "#camera", backgroundColor: "#222" }, [
           h(Resources),
           h(Fog),
           h(Camera),

--- a/packages/loaders/src/three-gltf-asset.ts
+++ b/packages/loaders/src/three-gltf-asset.ts
@@ -38,17 +38,6 @@ export class ThreeGLTFAsset extends ThreeElement.for(Group) {
 
   protected _url?: string
 
-  attributeChangedCallback(name: string, oldValue: string, newValue: string) {
-    switch (name) {
-      case "url":
-        this.url = newValue
-        return true
-
-      default:
-        return super.attributeChangedCallback(name, oldValue, newValue)
-    }
-  }
-
   private setupGLTF(gltf: GLTF) {
     /* Create a copy of the GLTF just for this element */
     const scene = gltf.scene.clone(true)

--- a/packages/loaders/src/three-gltf-asset.ts
+++ b/packages/loaders/src/three-gltf-asset.ts
@@ -5,6 +5,8 @@ import { ThreeElement, registerThreeElement } from "three-elements"
 const loader = new GLTFLoader()
 
 export class ThreeGLTFAsset extends ThreeElement.for(Group) {
+  static exposedProperties = [...ThreeElement.exposedProperties, "url"]
+
   /**
    * Has the GLTF been loaded?
    */

--- a/packages/three-elements/package.json
+++ b/packages/three-elements/package.json
@@ -47,5 +47,8 @@
   "peerDependencies": {
     "three": ">=0.121.0"
   },
-  "gitHead": "c3f0dd533ca26538b691b7ff6f5a7548f3512c36"
+  "gitHead": "c3f0dd533ca26538b691b7ff6f5a7548f3512c36",
+  "devDependencies": {
+    "sinon": "^9.2.4"
+  }
 }

--- a/packages/three-elements/src/BaseElement.ts
+++ b/packages/three-elements/src/BaseElement.ts
@@ -182,29 +182,13 @@ export class BaseElement extends HTMLElement {
     /*
     We're going to look for a property that matches the camelcased version of the
     attribute name. If we can write to it (and it's not a function), we'll
-    automatically set it.
+    directly set it.
     */
 
     const propName = camelize(key) as keyof this
-    console.log(key, propName, typeof this[propName])
 
     if (propName in this && typeof this[propName] !== "function") {
-      /*
-      If the property is an object, we'll assume that this attribute's new
-      string value refers to another DOM element, and grab the object that is
-      wrapped by it and use it as our property's new value here.
-      */
-      if (typeof this[propName] === "object") {
-        this[propName] = getThreeObjectBySelector(value)
-        return true
-      }
-
-      /*
-      If we've reached this point, we're probably dealing with a scalar value, so
-      just assign the damn thing directly.
-      */
       applyProps(this, { [propName]: value })
-
       return true
     }
 

--- a/packages/three-elements/src/BaseElement.ts
+++ b/packages/three-elements/src/BaseElement.ts
@@ -2,9 +2,8 @@ import { ThreeGame, TickerFunction } from "./elements/three-game"
 import { ThreeScene } from "./elements/three-scene"
 import { TickerCallbacks } from "./TickerCallbacks"
 import { IConstructable } from "./types"
-import { applyProps } from "./util/applyProps"
+import { applyProp } from "./util/applyProps"
 import { camelize } from "./util/camelize"
-import { getThreeObjectBySelector } from "./util/getThreeObjectBySelector"
 
 /**
  * The `BaseElement` class extends the built-in HTMLElement class with a bit of convenience
@@ -185,10 +184,10 @@ export class BaseElement extends HTMLElement {
     directly set it.
     */
 
-    const propName = camelize(key) as keyof this
+    const propName = camelize(key)
 
-    if (propName in this && typeof this[propName] !== "function") {
-      applyProps(this, { [propName]: value })
+    if (propName in this && typeof this[propName as keyof this] !== "function") {
+      applyProp(this, propName, value)
       return true
     }
 

--- a/packages/three-elements/src/BaseElement.ts
+++ b/packages/three-elements/src/BaseElement.ts
@@ -183,8 +183,7 @@ export class BaseElement extends HTMLElement {
   }
 
   attributeChangedCallback(key: string, _: string | null, value: string): boolean {
-    const propName = camelize(key)
-    return applyPropWithDirective(this, propName, value)
+    return applyPropWithDirective(this, camelize(key), value)
   }
 
   /**

--- a/packages/three-elements/src/BaseElement.ts
+++ b/packages/three-elements/src/BaseElement.ts
@@ -36,8 +36,10 @@ export class BaseElement extends HTMLElement {
       throw "Something is accessing my .game property while I'm not connected. This shouldn't happen! 😭"
 
     const game = this.find((node) => node instanceof ThreeGame) as ThreeGame
+
     if (!game)
       throw "No <three-game> tag found! If you're seeing this error, it might be a sign that you're importing multiple versions of three-elements."
+
     return game
   }
 
@@ -55,9 +57,13 @@ export class BaseElement extends HTMLElement {
       throw "Something is accessing my .scene property while I'm not connected. This shouldn't happen! 😭"
 
     const scene = this.find((node: any) => node.object?.isScene) as ThreeScene
+
     if (!scene) throw "No <three-scene> tag found!"
+
     return scene
   }
+
+  /*** TICKER CALLBACKS ***/
 
   callbacks = new TickerCallbacks(this)
 

--- a/packages/three-elements/src/BaseElement.ts
+++ b/packages/three-elements/src/BaseElement.ts
@@ -186,9 +186,6 @@ export class BaseElement extends HTMLElement {
 
     const propName = camelize(key)
 
-    /* We'll skip functions, HTMLElement and the browser will take care of these. */
-    if (typeof this[propName as keyof this] === "function") return true
-
     /* Try to apply the prop! */
     applyProp(this, propName, value)
 

--- a/packages/three-elements/src/BaseElement.ts
+++ b/packages/three-elements/src/BaseElement.ts
@@ -186,11 +186,14 @@ export class BaseElement extends HTMLElement {
 
     const propName = camelize(key)
 
-    if (propName in this && typeof this[propName as keyof this] !== "function") {
-      applyProp(this, propName, value)
-      return true
-    }
+    /* We'll skip functions, HTMLElement and the browser will take care of these. */
+    if (typeof this[propName as keyof this] === "function") return true
 
+    /* Try to apply the prop! */
+    applyProp(this, propName, value)
+
+    /* We don't know if we actually successfully applied the property, so let's
+       return false here. */
     return false
   }
 

--- a/packages/three-elements/src/BaseElement.ts
+++ b/packages/three-elements/src/BaseElement.ts
@@ -2,7 +2,7 @@ import { ThreeGame, TickerFunction } from "./elements/three-game"
 import { ThreeScene } from "./elements/three-scene"
 import { TickerCallbacks } from "./TickerCallbacks"
 import { IConstructable } from "./types"
-import { applyProp, applyPropWithDirective } from "./util/applyProps"
+import { applyPropWithDirective } from "./util/applyProps"
 import { camelize } from "./util/camelize"
 
 /**
@@ -13,6 +13,13 @@ import { camelize } from "./util/camelize"
  * need access to the game's ticker or renderer.
  */
 export class BaseElement extends HTMLElement {
+  /**
+   * A list of properties that can also be set through attributes on the element's tag.
+   * Attribute names are expected to be kebab-cased versions of the original
+   * property names (eg. "renderTick" can be set through the attribute "render-tick".)
+   */
+  static exposedProperties = ["tick", "lateTick", "frameTick", "renderTick"]
+
   isMounted = false
 
   /**

--- a/packages/three-elements/src/BaseElement.ts
+++ b/packages/three-elements/src/BaseElement.ts
@@ -176,22 +176,8 @@ export class BaseElement extends HTMLElement {
   }
 
   attributeChangedCallback(key: string, _: string | null, value: string): boolean {
-    this.debug("attributeChangedCallback", key, value)
-
-    /*
-    We're going to look for a property that matches the camelcased version of the
-    attribute name. If we can write to it (and it's not a function), we'll
-    directly set it.
-    */
-
     const propName = camelize(key)
-
-    /* Try to apply the prop! */
-    applyProp(this, propName, value)
-
-    /* We don't know if we actually successfully applied the property, so let's
-       return false here. */
-    return false
+    return applyProp(this, propName, value)
   }
 
   /**

--- a/packages/three-elements/src/BaseElement.ts
+++ b/packages/three-elements/src/BaseElement.ts
@@ -186,6 +186,7 @@ export class BaseElement extends HTMLElement {
     */
 
     const propName = camelize(key) as keyof this
+    console.log(key, propName, typeof this[propName])
 
     if (propName in this && typeof this[propName] !== "function") {
       /*
@@ -195,15 +196,6 @@ export class BaseElement extends HTMLElement {
       */
       if (typeof this[propName] === "object") {
         this[propName] = getThreeObjectBySelector(value)
-        return true
-      }
-
-      /*
-      If the property is a function and starts with "on", we'll assume that
-      the attribute's string value is the body of a DOM event listener,
-      and handle it accordingly. */
-      if (typeof this[propName] === "function" && key.startsWith("on")) {
-        this[propName] = new Function(value).bind(this)
         return true
       }
 

--- a/packages/three-elements/src/BaseElement.ts
+++ b/packages/three-elements/src/BaseElement.ts
@@ -2,7 +2,7 @@ import { ThreeGame, TickerFunction } from "./elements/three-game"
 import { ThreeScene } from "./elements/three-scene"
 import { TickerCallbacks } from "./TickerCallbacks"
 import { IConstructable } from "./types"
-import { applyProp } from "./util/applyProps"
+import { applyProp, applyPropWithDirective } from "./util/applyProps"
 import { camelize } from "./util/camelize"
 
 /**
@@ -177,7 +177,7 @@ export class BaseElement extends HTMLElement {
 
   attributeChangedCallback(key: string, _: string | null, value: string): boolean {
     const propName = camelize(key)
-    return applyProp(this, propName, value)
+    return applyPropWithDirective(this, propName, value)
   }
 
   /**

--- a/packages/three-elements/src/BaseElement.ts
+++ b/packages/three-elements/src/BaseElement.ts
@@ -160,10 +160,14 @@ export class BaseElement extends HTMLElement {
     })
   }
 
+  /**
+   * Helper method that will make sure all attributes set on the element are passed
+   * through `attributeChangedCallback`. We mostly need this because of how we're
+   * _not_ using `observedAttributes`.
+   */
   applyAllAttributes() {
-    const attributes = this.getAllAttributes()
-    for (const key in attributes) {
-      this.attributeChangedCallback(key, "", attributes[key])
+    for (const key of this.getAttributeNames()) {
+      this.attributeChangedCallback(key, "", this.getAttribute(key))
     }
   }
 
@@ -188,18 +192,8 @@ export class BaseElement extends HTMLElement {
     }
   }
 
-  attributeChangedCallback(key: string, _: string | null, value: string): boolean {
+  attributeChangedCallback(key: string, _: any, value: any): boolean {
     return applyPropWithDirective(this, camelize(key), value)
-  }
-
-  /**
-   * Returns a dictionary containing all attributes on this element.
-   */
-  getAllAttributes() {
-    return this.getAttributeNames().reduce((acc, name) => {
-      acc[name] = this.getAttribute(name)
-      return acc
-    }, {} as Record<string, any>)
   }
 
   requestFrame() {

--- a/packages/three-elements/src/ThreeElement.ts
+++ b/packages/three-elements/src/ThreeElement.ts
@@ -5,6 +5,8 @@ import { applyProp, applyPropWithDirective } from "./util/applyProps"
 import { attributeValueToArray } from "./util/attributeValueToArray"
 
 export class ThreeElement<T = any> extends BaseElement {
+  static exposedProperties = BaseElement.exposedProperties
+
   /** Constructor that will instantiate our object. */
   static threeConstructor?: IConstructable
 

--- a/packages/three-elements/src/ThreeElement.ts
+++ b/packages/three-elements/src/ThreeElement.ts
@@ -4,11 +4,18 @@ import { IConstructable, isDisposable } from "./types"
 import { applyProp, applyPropWithDirective } from "./util/applyProps"
 import { attributeValueToArray } from "./util/attributeValueToArray"
 
+/**
+ * The `ThreeElement` class extends `BaseElement` with some code that manages an instance
+ * of a given Three.js class. It's the centerpiece of three-elements, with most elements
+ * provided by the library derived from it.
+ */
 export class ThreeElement<T = any> extends BaseElement {
   static exposedProperties = BaseElement.exposedProperties
 
   /** Constructor that will instantiate our object. */
   static threeConstructor?: IConstructable
+
+  /*** MANAGED THREE.JS OBJECT ***/
 
   /** The THREE.* object managed by this element. */
   get object() {
@@ -38,7 +45,11 @@ export class ThreeElement<T = any> extends BaseElement {
         object = new constructor()
       }
 
-      /* Store a reference to this element in the wrapped object's userData. */
+      /*
+      Store a reference to this element in the wrapped object's userData -- we'll
+      need it whenever we want to link a Three.js scene object back to the DOM element
+      that owns it.
+      */
       if (object instanceof THREE.Object3D) {
         object.userData.threeElement = this
       }
@@ -109,20 +120,23 @@ export class ThreeElement<T = any> extends BaseElement {
         attach = "geometry"
       } else if ((this.object as any).isFog) {
         attach = "fog"
+      } else if ((this.object as any).isColor) {
+        attach = "color"
       }
     }
 
-    /* If the wrapped object has an "attach" attribute, automatically assign it to the
-       value of the same name in the parent object. */
+    /*
+    If the wrapped object has an "attach" attribute, automatically assign it to the
+    value of the same name in the parent object.
+    */
     if (attach) {
       const parent = this.find((node) => node instanceof ThreeElement)
 
       if (!parent) {
         this.error(`Tried to attach to the "${attach} property, but there was no parent! 😢`)
-        return
       } else if (parent instanceof ThreeElement) {
         this.debug("Attaching to:", parent)
-        parent.object[attach!] = this.object
+        parent.object[attach] = this.object
       } else {
         this.error(
           `Tried to attach to the "${attach} property of ${parent}, but it's not a ThreeElement! It's possible that the target element has not been upgraded to a ThreeElement yet. 😢`

--- a/packages/three-elements/src/ThreeElement.ts
+++ b/packages/three-elements/src/ThreeElement.ts
@@ -139,7 +139,7 @@ export class ThreeElement<T = any> extends BaseElement {
     Okay, at this point, we'll just assume that the property lives on the wrapped object.
     Good times! Let's assign it directly. If we have an object, that is.
     */
-    return this.object && applyProp(this.object, key, newValue)
+    return this.object ? applyProp(this.object, key, newValue) : false
   }
 
   static for<T>(constructor: IConstructable<T>): IConstructable<ThreeElement<T>> {

--- a/packages/three-elements/src/ThreeElement.ts
+++ b/packages/three-elements/src/ThreeElement.ts
@@ -132,36 +132,18 @@ export class ThreeElement<T = any> extends BaseElement {
   attributeChangedCallback(key: string, oldValue: any, newValue: any) {
     if (super.attributeChangedCallback(key, oldValue, newValue)) return true
 
-    switch (key) {
-      /* NOOPs */
-      case "args":
-      case "id":
-        return true
+    /* Explicit NOOPs */
+    if (key in ["args", "id"]) {
+      return true
+    }
 
-      /* Event handlers that we will want to convert into a function first */
-      case "onpointerdown":
-      case "onpointerup":
-      case "onpointerenter":
-      case "onpointerleave":
-      case "onpointerover":
-      case "onpointerout":
-      case "onclick":
-      case "ondblclick":
-        this[key] = new Function(newValue).bind(this)
-        return true
-
-      /*
-      If we've reached this point, we're dealing with an attribute that we don't know.
-      */
-      default:
-        /*
-        Okay, at this point, we'll just assume that the property lives on the wrapped object.
-        Good times! Let's assign it directly.
-        */
-        if (this.object) {
-          applyProps(this.object, { [key]: newValue })
-          return true
-        }
+    /*
+    Okay, at this point, we'll just assume that the property lives on the wrapped object.
+    Good times! Let's assign it directly. If we have an object, that is.
+    */
+    if (this.object) {
+      applyProps(this.object, { [key]: newValue })
+      return true
     }
 
     return false

--- a/packages/three-elements/src/ThreeElement.ts
+++ b/packages/three-elements/src/ThreeElement.ts
@@ -1,7 +1,7 @@
 import * as THREE from "three"
 import { BaseElement } from "./BaseElement"
 import { IConstructable, isDisposable } from "./types"
-import { applyProps } from "./util/applyProps"
+import { applyProp } from "./util/applyProps"
 import { attributeValueToArray } from "./util/attributeValueToArray"
 
 export class ThreeElement<T = any> extends BaseElement {
@@ -142,7 +142,7 @@ export class ThreeElement<T = any> extends BaseElement {
     Good times! Let's assign it directly. If we have an object, that is.
     */
     if (this.object) {
-      applyProps(this.object, { [key]: newValue })
+      applyProp(this.object, key, newValue)
       return true
     }
 

--- a/packages/three-elements/src/ThreeElement.ts
+++ b/packages/three-elements/src/ThreeElement.ts
@@ -58,6 +58,8 @@ export class ThreeElement<T = any> extends BaseElement {
     }
   }
 
+  /*** CALLBACKS ***/
+
   mountedCallback() {
     super.mountedCallback()
 
@@ -88,6 +90,16 @@ export class ThreeElement<T = any> extends BaseElement {
     }
 
     super.removedCallback()
+  }
+
+  attributeChangedCallback(key: string, oldValue: any, newValue: any) {
+    if (super.attributeChangedCallback(key, oldValue, newValue)) return true
+
+    /*
+    Okay, at this point, we'll just assume that the property lives on the wrapped object.
+    Good times! Let's assign it. If we have an object, that is.
+    */
+    return this.object ? applyPropWithDirective(this.object, key, newValue) : false
   }
 
   protected addObjectToParent() {
@@ -143,16 +155,6 @@ export class ThreeElement<T = any> extends BaseElement {
         )
       }
     }
-  }
-
-  attributeChangedCallback(key: string, oldValue: any, newValue: any) {
-    if (super.attributeChangedCallback(key, oldValue, newValue)) return true
-
-    /*
-    Okay, at this point, we'll just assume that the property lives on the wrapped object.
-    Good times! Let's assign it. If we have an object, that is.
-    */
-    return this.object ? applyPropWithDirective(this.object, key, newValue) : false
   }
 
   static for<T>(constructor: IConstructable<T>): IConstructable<ThreeElement<T>> {

--- a/packages/three-elements/src/ThreeElement.ts
+++ b/packages/three-elements/src/ThreeElement.ts
@@ -1,7 +1,7 @@
 import * as THREE from "three"
 import { BaseElement } from "./BaseElement"
 import { IConstructable, isDisposable } from "./types"
-import { applyProp } from "./util/applyProps"
+import { applyProp, applyPropWithDirective } from "./util/applyProps"
 import { attributeValueToArray } from "./util/attributeValueToArray"
 
 export class ThreeElement<T = any> extends BaseElement {
@@ -139,7 +139,7 @@ export class ThreeElement<T = any> extends BaseElement {
     Okay, at this point, we'll just assume that the property lives on the wrapped object.
     Good times! Let's assign it directly. If we have an object, that is.
     */
-    return this.object ? applyProp(this.object, key, newValue) : false
+    return this.object ? applyPropWithDirective(this.object, key, newValue) : false
   }
 
   static for<T>(constructor: IConstructable<T>): IConstructable<ThreeElement<T>> {

--- a/packages/three-elements/src/ThreeElement.ts
+++ b/packages/three-elements/src/ThreeElement.ts
@@ -133,20 +133,13 @@ export class ThreeElement<T = any> extends BaseElement {
     if (super.attributeChangedCallback(key, oldValue, newValue)) return true
 
     /* Explicit NOOPs */
-    if (key in ["args", "id"]) {
-      return true
-    }
+    if (key in ["args", "id"]) return true
 
     /*
     Okay, at this point, we'll just assume that the property lives on the wrapped object.
     Good times! Let's assign it directly. If we have an object, that is.
     */
-    if (this.object) {
-      applyProp(this.object, key, newValue)
-      return true
-    }
-
-    return false
+    return this.object && applyProp(this.object, key, newValue)
   }
 
   static for<T>(constructor: IConstructable<T>): IConstructable<ThreeElement<T>> {

--- a/packages/three-elements/src/ThreeElement.ts
+++ b/packages/three-elements/src/ThreeElement.ts
@@ -134,12 +134,9 @@ export class ThreeElement<T = any> extends BaseElement {
   attributeChangedCallback(key: string, oldValue: any, newValue: any) {
     if (super.attributeChangedCallback(key, oldValue, newValue)) return true
 
-    /* Explicit NOOPs */
-    if (key in ["args", "id"]) return true
-
     /*
     Okay, at this point, we'll just assume that the property lives on the wrapped object.
-    Good times! Let's assign it directly. If we have an object, that is.
+    Good times! Let's assign it. If we have an object, that is.
     */
     return this.object ? applyPropWithDirective(this.object, key, newValue) : false
   }

--- a/packages/three-elements/src/elements/three-rect-area-light-helper.ts
+++ b/packages/three-elements/src/elements/three-rect-area-light-helper.ts
@@ -1,24 +1,8 @@
 import { RectAreaLightHelper } from "three/examples/jsm/helpers/RectAreaLightHelper"
 import { ThreeElement } from "../ThreeElement"
-import { getThreeObjectBySelector } from "../util/getThreeObjectBySelector"
 import { registerThreeElement } from "../util/registerElement"
 
-export class ThreeRectAreaLightHelper extends ThreeElement.for(RectAreaLightHelper) {
-  attributeChangedCallback(
-    name: string,
-    oldValue: string | undefined,
-    newValue: string | undefined
-  ) {
-    switch (name) {
-      case "light":
-        if (newValue) this.object!.light = getThreeObjectBySelector(newValue)
-        return true
-
-      default:
-        return super.attributeChangedCallback(name, oldValue, newValue)
-    }
-  }
-}
+export class ThreeRectAreaLightHelper extends ThreeElement.for(RectAreaLightHelper) {}
 
 registerThreeElement(
   "three-rect-area-light-helper",

--- a/packages/three-elements/src/elements/three-scene.ts
+++ b/packages/three-elements/src/elements/three-scene.ts
@@ -69,18 +69,10 @@ export class ThreeScene extends ThreeElement.for(Scene) {
     super.disconnectedCallback()
   }
 
-  attributeChangedCallback(name: string, oldValue: string, newValue: string) {
-    switch (name) {
-      case "background-color":
-        this.object!.background = new Color(newValue)
-        return true
-
-      case "camera":
-        const camera = getThreeObjectBySelector(newValue)
-        if (camera) this.camera = camera
-    }
-
-    return super.attributeChangedCallback(name, oldValue, newValue)
+  /* backgroundColor property.
+     TODO: remove this */
+  set backgroundColor(v) {
+    this.object!.background = new Color(v)
   }
 
   handleWindowResize() {

--- a/packages/three-elements/src/elements/three-scene.ts
+++ b/packages/three-elements/src/elements/three-scene.ts
@@ -5,6 +5,13 @@ import { getThreeObjectBySelector } from "../util/getThreeObjectBySelector"
 import { registerThreeElement } from "../util/registerElement"
 
 export class ThreeScene extends ThreeElement.for(Scene) {
+  /**
+   * Background color of the scene.
+   */
+  set backgroundColor(v: string) {
+    this.object!.background = new Color(v)
+  }
+
   /** The current camera that is being used to render the scene. */
   private _camera: Camera = new PerspectiveCamera(
     75,
@@ -67,12 +74,6 @@ export class ThreeScene extends ThreeElement.for(Scene) {
     window.removeEventListener("resize", this.handleWindowResize)
 
     super.disconnectedCallback()
-  }
-
-  /* backgroundColor property.
-     TODO: remove this */
-  set backgroundColor(v) {
-    this.object!.background = new Color(v)
   }
 
   handleWindowResize() {

--- a/packages/three-elements/src/elements/three-scene.ts
+++ b/packages/three-elements/src/elements/three-scene.ts
@@ -1,7 +1,6 @@
 import { Camera, Color, OrthographicCamera, PerspectiveCamera, Scene, WebGLRenderer } from "three"
 import { PointerEvents } from "../PointerEvents"
 import { ThreeElement } from "../ThreeElement"
-import { getThreeObjectBySelector } from "../util/getThreeObjectBySelector"
 import { registerThreeElement } from "../util/registerElement"
 
 export class ThreeScene extends ThreeElement.for(Scene) {

--- a/packages/three-elements/src/elements/three-scene.ts
+++ b/packages/three-elements/src/elements/three-scene.ts
@@ -25,8 +25,12 @@ export class ThreeScene extends ThreeElement.for(Scene) {
   }
 
   set camera(camera) {
-    this._camera = camera
-    this.handleWindowResize()
+    if (camera instanceof Camera) {
+      this._camera = camera
+      this.handleWindowResize()
+    } else {
+      console.error("Can't accept this as a camera:", camera)
+    }
   }
 
   /** The pointer events system. */

--- a/packages/three-elements/src/elements/three-scene.ts
+++ b/packages/three-elements/src/elements/three-scene.ts
@@ -4,6 +4,8 @@ import { ThreeElement } from "../ThreeElement"
 import { registerThreeElement } from "../util/registerElement"
 
 export class ThreeScene extends ThreeElement.for(Scene) {
+  static exposedProperties = [...ThreeElement.exposedProperties, "backgroundColor", "camera"]
+
   /**
    * Background color of the scene.
    */

--- a/packages/three-elements/src/elements/three-scene.ts
+++ b/packages/three-elements/src/elements/three-scene.ts
@@ -30,7 +30,7 @@ export class ThreeScene extends ThreeElement.for(Scene) {
       this._camera = camera
       this.handleWindowResize()
     } else {
-      console.error("Can't accept this as a camera:", camera)
+      this.error("Can't accept this as a camera:", camera)
     }
   }
 

--- a/packages/three-elements/src/elements/three-template.ts
+++ b/packages/three-elements/src/elements/three-template.ts
@@ -25,7 +25,7 @@ export class ThreeTemplate extends HTMLElement {
     const tag = this.getAttribute("tag")
 
     if (!tag || tag === "") {
-      console.error("You must specify the tag attribute when defining a <three-template>.")
+      this.error("You must specify the tag attribute when defining a <three-template>.")
       return
     }
 

--- a/packages/three-elements/src/elements/three-template.ts
+++ b/packages/three-elements/src/elements/three-template.ts
@@ -25,7 +25,7 @@ export class ThreeTemplate extends HTMLElement {
     const tag = this.getAttribute("tag")
 
     if (!tag || tag === "") {
-      this.error("You must specify the tag attribute when defining a <three-template>.")
+      console.error("You must specify the tag attribute when defining a <three-template>.")
       return
     }
 

--- a/packages/three-elements/src/elements/three-texture.ts
+++ b/packages/three-elements/src/elements/three-texture.ts
@@ -25,16 +25,6 @@ export class ThreeTexture extends ThreeElement.for(Texture) {
 
     this._url = url
   }
-
-  attributeChangedCallback(name: string, oldValue: string, newValue: string) {
-    switch (name) {
-      case "url":
-        this.url = newValue
-        return true
-      default:
-        return super.attributeChangedCallback(name, oldValue, newValue)
-    }
-  }
 }
 
 registerThreeElement("three-texture", "Texture", ThreeTexture)

--- a/packages/three-elements/src/elements/three-texture.ts
+++ b/packages/three-elements/src/elements/three-texture.ts
@@ -3,6 +3,8 @@ import { ThreeElement } from "../ThreeElement"
 import { registerThreeElement } from "../util/registerElement"
 
 export class ThreeTexture extends ThreeElement.for(Texture) {
+  static exposedProperties = [...ThreeElement.exposedProperties, "url"]
+
   private _url?: string
 
   public get url() {

--- a/packages/three-elements/src/util/applyProps.ts
+++ b/packages/three-elements/src/util/applyProps.ts
@@ -29,7 +29,8 @@ export const applyPropWithDirective = (
       return referencedObject ? applyProp(object, rest, referencedObject) : false
 
     default:
-      return applyProp(object, rest, value)
+      console.error(`Unknow directive: ${directive}`)
+      return false
   }
 }
 

--- a/packages/three-elements/src/util/applyProps.ts
+++ b/packages/three-elements/src/util/applyProps.ts
@@ -1,89 +1,91 @@
 import { IStringIndexable } from "../types"
+import { attributeValueToArray } from "./attributeValueToArray"
 import { camelize } from "./camelize"
 import { getThreeObjectBySelector } from "./getThreeObjectBySelector"
-import { attributeValueToArray } from "./attributeValueToArray"
 import { parseDeg } from "./parseDeg"
 
 const IGNORED_KEYS = ["id"]
 
 export const applyProps = (object: IStringIndexable, props: IStringIndexable) => {
-  for (const incoming in props) {
-    const value = props[incoming]
-    let [firstKey, ...rest] = incoming.split(/[\.:]/)
-
-    const key = camelize(firstKey)
-
-    /* Skip all ignored keys. */
-    if (IGNORED_KEYS.includes(key)) return
-
-    /* Skip all data attributes. */
-    if (firstKey.startsWith("data-")) return
-
-    /* Recursively handle nested keys, eg. position.x */
-    if (key in object && rest.length > 0) {
-      applyProps(object[key], { [rest.join(".")]: value })
-      return
-    }
-
-    /*
-    Handle boolean properties. We will check against the only values that we consider falsey here,
-    taking into account that they might be coming from string-based HTML element attributes, where a
-    stand-alone boolean attribute like "cast-shadow" will emit a value of "". Eh!
-    */
-    if (typeof object[key] === "boolean") {
-      object[key] = ![undefined, null, false, "no", "false"].includes(value)
-      return
-    }
-
-    /* It is attribute-setting time! Let's try to parse the value. */
-    const parsed = typeof value === "string" ? parseJson(value) ?? parseDeg(value) : value
-
-    /* Handle properties that provide .set methods */
-    if (object[key]?.set !== undefined) {
-      /* If the value is an array, feed its destructured representation to the set method. */
-      if (Array.isArray(parsed)) {
-        object[key].set(...parsed)
-        return
-      }
-
-      /* A bit of special handling for "scale" properties, where we'll also accept a single numerical value */
-      if (key === "scale" && typeof parsed === "number") {
-        object[key].setScalar(parsed)
-        return
-      }
-
-      /* If we have a parsed value, set it directly */
-      if (parsed) {
-        object[key].set(parsed)
-        return
-      }
-
-      /* Otherwise, set the original string value, but split by commas */
-      const list = attributeValueToArray(value)
-      object[key].set(...list)
-      return
-    }
-
-    /*
-    Is the property an object? In that case, we'll assume that the string value of the attribute
-    contains a DOM selector that references another object that we should assign here.
-    */
-    if (typeof object[key] === "object") {
-      const referencedObject = getThreeObjectBySelector(value)
-
-      if (referencedObject) {
-        object[key] = referencedObject
-      }
-
-      return
-    }
-
-    /*
-    If we've reached this point, we're finally able to set a property on the object.
-    Amazing! But let's only do it if the property key is actually known.
-    */
-    if (key in object) object[key] = parsed !== undefined ? parsed : value
+  for (const name in props) {
+    applyProp(object, name, props[name])
   }
+}
+
+export const applyProp = (object: IStringIndexable, name: string, value: any) => {
+  let [firstKey, ...rest] = name.split(/[\.:]/)
+  const key = camelize(firstKey)
+
+  /* Skip all ignored keys. */
+  if (IGNORED_KEYS.includes(key)) return
+
+  /* Skip all data attributes. */
+  if (firstKey.startsWith("data-")) return
+
+  /* Recursively handle nested keys, eg. position.x */
+  if (key in object && rest.length > 0) {
+    applyProp(object[key], rest.join("."), value)
+    return
+  }
+
+  /*
+  Handle boolean properties. We will check against the only values that we consider falsey here,
+  taking into account that they might be coming from string-based HTML element attributes, where a
+  stand-alone boolean attribute like "cast-shadow" will emit a value of "". Eh!
+  */
+  if (typeof object[key] === "boolean") {
+    object[key] = ![undefined, null, false, "no", "false"].includes(value)
+    return
+  }
+
+  /* It is attribute-setting time! Let's try to parse the value. */
+  const parsed = typeof value === "string" ? parseJson(value) ?? parseDeg(value) : value
+
+  /* Handle properties that provide .set methods */
+  if (object[key]?.set !== undefined) {
+    /* If the value is an array, feed its destructured representation to the set method. */
+    if (Array.isArray(parsed)) {
+      object[key].set(...parsed)
+      return
+    }
+
+    /* A bit of special handling for "scale" properties, where we'll also accept a single numerical value */
+    if (key === "scale" && typeof parsed === "number") {
+      object[key].setScalar(parsed)
+      return
+    }
+
+    /* If we have a parsed value, set it directly */
+    if (parsed) {
+      object[key].set(parsed)
+      return
+    }
+
+    /* Otherwise, set the original string value, but split by commas */
+    const list = attributeValueToArray(value)
+    object[key].set(...list)
+    return
+  }
+
+  /*
+  Is the property an object? In that case, we'll assume that the string value of the attribute
+  contains a DOM selector that references another object that we should assign here.
+  */
+  if (typeof object[key] === "object") {
+    const referencedObject = getThreeObjectBySelector(value)
+
+    if (referencedObject) {
+      object[key] = referencedObject
+    }
+
+    return
+  }
+
+  /*
+  If we've reached this point, we're finally able to set a property on the object.
+  Amazing! But let's only do it if the property key is actually known.
+  */
+  if (key in object) object[key] = parsed !== undefined ? parsed : value
 }
 
 const parseJson = (value: string) => {

--- a/packages/three-elements/src/util/applyProps.ts
+++ b/packages/three-elements/src/util/applyProps.ts
@@ -17,27 +17,25 @@ export const applyProp = (
   name: string,
   value: any,
   directive: string = ""
-) => {
+): boolean => {
   let [firstKey, ...rest] = name.split(/[\.:]/)
 
   /* Check for "ref" directive */
   if (firstKey === "ref") {
-    applyProp(object, rest.join("."), value, "ref")
-    return
+    return applyProp(object, rest.join("."), value, "ref")
   }
 
   const key = camelize(firstKey)
 
   /* Skip all ignored keys. */
-  if (IGNORED_KEYS.includes(key)) return
+  if (IGNORED_KEYS.includes(key)) return false
 
   /* Skip all data attributes. */
-  if (firstKey.startsWith("data-")) return
+  if (firstKey.startsWith("data-")) return false
 
   /* Recursively handle nested keys, eg. position.x */
   if (key in object && rest.length > 0) {
-    applyProp(object[key], rest.join("."), value, directive)
-    return
+    return applyProp(object[key], rest.join("."), value, directive)
   }
 
   /*
@@ -47,7 +45,7 @@ export const applyProp = (
   */
   if (typeof object[key] === "boolean") {
     object[key] = ![undefined, null, false, "no", "false"].includes(value)
-    return
+    return true
   }
 
   /*
@@ -55,7 +53,7 @@ export const applyProp = (
   */
   if (typeof object[key] === "function") {
     object[key] = new Function(value).bind(object)
-    return
+    return true
   }
 
   /* It is attribute-setting time! Let's try to parse the value. */
@@ -66,25 +64,25 @@ export const applyProp = (
     /* If the value is an array, feed its destructured representation to the set method. */
     if (Array.isArray(parsed)) {
       object[key].set(...parsed)
-      return
+      return true
     }
 
     /* A bit of special handling for "scale" properties, where we'll also accept a single numerical value */
     if (key === "scale" && typeof parsed === "number") {
       object[key].setScalar(parsed)
-      return
+      return true
     }
 
     /* If we have a parsed value, set it directly */
     if (parsed) {
       object[key].set(parsed)
-      return
+      return true
     }
 
     /* Otherwise, set the original string value, but split by commas */
     const list = attributeValueToArray(value)
     object[key].set(...list)
-    return
+    return true
   }
 
   /*
@@ -95,16 +93,22 @@ export const applyProp = (
     const referencedObject = getThreeObjectBySelector(value)
     if (referencedObject) {
       object[key] = referencedObject
+      return true
+    } else {
+      return false
     }
-
-    return
   }
 
   /*
   If we've reached this point, we're finally able to set a property on the object.
   Amazing! But let's only do it if the property key is actually known.
   */
-  if (key in object) object[key] = parsed !== undefined ? parsed : value
+  if (key in object) {
+    object[key] = parsed !== undefined ? parsed : value
+    return true
+  } else {
+    return false
+  }
 }
 
 const parseJson = (value: string) => {

--- a/packages/three-elements/src/util/applyProps.ts
+++ b/packages/three-elements/src/util/applyProps.ts
@@ -12,14 +12,29 @@ export const applyProps = (object: IStringIndexable, props: IStringIndexable) =>
   }
 }
 
-export const applyProp = (object: IStringIndexable, name: string, value: any): boolean => {
-  let [firstKey, ...rest] = name.split(/[\.:]/)
+export const applyPropWithDirective = (
+  object: IStringIndexable,
+  name: string,
+  value: any
+): boolean => {
+  let [directive, rest] = name.split(":")
+
+  /* If no rest was returned, there was no directive. */
+  if (!rest) return applyProp(object, name, value)
 
   /* Resolve "ref" directive */
-  if (firstKey === "ref") {
-    const referencedObject = getThreeObjectBySelector(value)
-    return referencedObject ? applyProp(object, rest.join("."), referencedObject) : false
+  switch (directive) {
+    case "ref":
+      const referencedObject = getThreeObjectBySelector(value)
+      return referencedObject ? applyProp(object, rest, referencedObject) : false
+
+    default:
+      return applyProp(object, rest, value)
   }
+}
+
+export const applyProp = (object: IStringIndexable, name: string, value: any): boolean => {
+  let [firstKey, ...rest] = name.split(".")
 
   const key = camelize(firstKey)
 

--- a/packages/three-elements/src/util/applyProps.ts
+++ b/packages/three-elements/src/util/applyProps.ts
@@ -12,17 +12,13 @@ export const applyProps = (object: IStringIndexable, props: IStringIndexable) =>
   }
 }
 
-export const applyProp = (
-  object: IStringIndexable,
-  name: string,
-  value: any,
-  directive: string = ""
-): boolean => {
+export const applyProp = (object: IStringIndexable, name: string, value: any): boolean => {
   let [firstKey, ...rest] = name.split(/[\.:]/)
 
-  /* Check for "ref" directive */
+  /* Resolve "ref" directive */
   if (firstKey === "ref") {
-    return applyProp(object, rest.join("."), value, "ref")
+    const referencedObject = getThreeObjectBySelector(value)
+    return referencedObject ? applyProp(object, rest.join("."), referencedObject) : false
   }
 
   const key = camelize(firstKey)
@@ -35,7 +31,7 @@ export const applyProp = (
 
   /* Recursively handle nested keys, eg. position.x */
   if (key in object && rest.length > 0) {
-    return applyProp(object[key], rest.join("."), value, directive)
+    return applyProp(object[key], rest.join("."), value)
   }
 
   /*
@@ -87,21 +83,6 @@ export const applyProp = (
     const list = attributeValueToArray(value)
     object[key].set(...list)
     return true
-  }
-
-  /*
-  Is the property an object? In that case, we'll assume that the string value of the attribute
-  contains a DOM selector that references another object that we should assign here.
-  */
-  if (key in object && directive === "ref") {
-    const referencedObject = getThreeObjectBySelector(value)
-
-    if (referencedObject) {
-      object[key] = referencedObject
-      return true
-    } else {
-      return false
-    }
   }
 
   /*

--- a/packages/three-elements/src/util/applyProps.ts
+++ b/packages/three-elements/src/util/applyProps.ts
@@ -89,8 +89,9 @@ export const applyProp = (
   Is the property an object? In that case, we'll assume that the string value of the attribute
   contains a DOM selector that references another object that we should assign here.
   */
-  if (typeof object[key] === "object" && directive === "ref") {
+  if (key in object && directive === "ref") {
     const referencedObject = getThreeObjectBySelector(value)
+
     if (referencedObject) {
       object[key] = referencedObject
       return true

--- a/packages/three-elements/src/util/applyProps.ts
+++ b/packages/three-elements/src/util/applyProps.ts
@@ -12,8 +12,20 @@ export const applyProps = (object: IStringIndexable, props: IStringIndexable) =>
   }
 }
 
-export const applyProp = (object: IStringIndexable, name: string, value: any) => {
+export const applyProp = (
+  object: IStringIndexable,
+  name: string,
+  value: any,
+  directive: string = ""
+) => {
   let [firstKey, ...rest] = name.split(/[\.:]/)
+
+  /* Check for "ref" directive */
+  if (firstKey === "ref") {
+    applyProp(object, rest.join("."), value, "ref")
+    return
+  }
+
   const key = camelize(firstKey)
 
   /* Skip all ignored keys. */
@@ -24,7 +36,7 @@ export const applyProp = (object: IStringIndexable, name: string, value: any) =>
 
   /* Recursively handle nested keys, eg. position.x */
   if (key in object && rest.length > 0) {
-    applyProp(object[key], rest.join("."), value)
+    applyProp(object[key], rest.join("."), value, directive)
     return
   }
 
@@ -71,9 +83,8 @@ export const applyProp = (object: IStringIndexable, name: string, value: any) =>
   Is the property an object? In that case, we'll assume that the string value of the attribute
   contains a DOM selector that references another object that we should assign here.
   */
-  if (typeof object[key] === "object") {
+  if (typeof object[key] === "object" && directive === "ref") {
     const referencedObject = getThreeObjectBySelector(value)
-
     if (referencedObject) {
       object[key] = referencedObject
     }

--- a/packages/three-elements/src/util/applyProps.ts
+++ b/packages/three-elements/src/util/applyProps.ts
@@ -50,6 +50,14 @@ export const applyProp = (
     return
   }
 
+  /*
+  Handle function properties.
+  */
+  if (typeof object[key] === "function") {
+    object[key] = new Function(value).bind(object)
+    return
+  }
+
   /* It is attribute-setting time! Let's try to parse the value. */
   const parsed = typeof value === "string" ? parseJson(value) ?? parseDeg(value) : value
 

--- a/packages/three-elements/src/util/applyProps.ts
+++ b/packages/three-elements/src/util/applyProps.ts
@@ -5,7 +5,7 @@ import { camelize } from "./camelize"
 import { getThreeObjectBySelector } from "./getThreeObjectBySelector"
 import { parseDeg } from "./parseDeg"
 
-const IGNORED_KEYS = ["id"]
+const IGNORED_KEYS = ["args", "id"]
 
 export const applyProps = (object: IStringIndexable, props: IStringIndexable) => {
   for (const name in props) {

--- a/packages/three-elements/src/util/applyProps.ts
+++ b/packages/three-elements/src/util/applyProps.ts
@@ -49,11 +49,15 @@ export const applyProp = (
   }
 
   /*
-  Handle function properties.
+  Handle function properties, but only if their name starts with "on".
   */
   if (typeof object[key] === "function") {
-    object[key] = new Function(value).bind(object)
-    return true
+    if (key.startsWith("on")) {
+      object[key] = new Function(value).bind(object)
+      return true
+    } else {
+      return false
+    }
   }
 
   /* It is attribute-setting time! Let's try to parse the value. */

--- a/packages/three-elements/test/dom-referencing.test.ts
+++ b/packages/three-elements/test/dom-referencing.test.ts
@@ -15,7 +15,7 @@ describe("<three-*> powered by ThreeElement", () => {
           ></three-mesh-standard-material>
 
           <!-- something that's using the resources -->
-          <three-mesh geometry="#geometry" material="#material"> </three-mesh>
+          <three-mesh ref:geometry="#geometry" ref:material="#material"> </three-mesh>
         </three-scene>
       </three-game>
     `)

--- a/packages/three-elements/test/three-element.test.ts
+++ b/packages/three-elements/test/three-element.test.ts
@@ -41,16 +41,6 @@ describe("<three-*> powered by ThreeElement", () => {
       expect(el.object.position.x).to.equal(1)
     })
 
-    it("supports colon attributes (position:x)", async () => {
-      const el = await renderMeshElement()
-
-      el.object.position.x = 0
-      expect(el.object.position.x).to.equal(0)
-
-      el.setAttribute("position:x", "1")
-      expect(el.object.position.x).to.equal(1)
-    })
-
     it("supports settable Vector3 attributes", async () => {
       const el = await renderMeshElement()
 

--- a/packages/three-elements/test/three-scene.test.ts
+++ b/packages/three-elements/test/three-scene.test.ts
@@ -6,7 +6,7 @@ describe("the args attribute", () => {
   const render = () =>
     fixture(html`
       <three-game>
-        <three-scene camera=".active">
+        <three-scene ref:camera=".active">
           <three-perspective-camera class="active" position="5, 5, 50"></three-perspective-camera>
         </three-scene>
       </three-game>

--- a/packages/three-elements/test/util/applyProps.test.ts
+++ b/packages/three-elements/test/util/applyProps.test.ts
@@ -2,7 +2,7 @@ import { expect } from "@open-wc/testing"
 import { applyProps, applyProp } from "../../src/util/applyProps"
 import * as THREE from "three"
 
-describe("applyProps", () => {
+describe("applyProp", () => {
   it("can directly assign root-level properties", () => {
     const object = {
       foo: 0
@@ -63,5 +63,18 @@ describe("applyProps", () => {
     expect(object.foo.x).to.equal(1)
     expect(object.foo.y).to.equal(2)
     expect(object.foo.z).to.equal(3)
+  })
+})
+
+describe("applyProps", () => {
+  const object = {
+    foo: 0,
+    bar: 0
+  }
+
+  it("assigns multiple values", () => {
+    applyProps(object, { foo: 1, bar: 2 })
+    expect(object.foo).to.equal(1)
+    expect(object.bar).to.equal(2)
   })
 })

--- a/packages/three-elements/test/util/applyProps.test.ts
+++ b/packages/three-elements/test/util/applyProps.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "@open-wc/testing"
-import { applyProps } from "../../src/util/applyProps"
+import { applyProps, applyProp } from "../../src/util/applyProps"
 import * as THREE from "three"
 
 describe("applyProps", () => {
@@ -7,7 +7,7 @@ describe("applyProps", () => {
     const object = {
       foo: 0
     }
-    applyProps(object, { foo: 1 })
+    applyProp(object, "foo", 1)
     expect(object.foo).to.equal(1)
   })
 
@@ -17,7 +17,7 @@ describe("applyProps", () => {
         bar: 0
       }
     }
-    applyProps(object, { "foo.bar": 1 })
+    applyProp(object, "foo.bar", 1)
     expect(object.foo.bar).to.equal(1)
   })
 
@@ -25,7 +25,7 @@ describe("applyProps", () => {
     const object = {
       foo: 0
     }
-    applyProps(object, { foo: "1.5" })
+    applyProp(object, "foo", "1.5")
     expect(object.foo).to.equal(1.5)
   })
 
@@ -33,7 +33,7 @@ describe("applyProps", () => {
     const object = {
       foo: 1
     }
-    applyProps(object, { foo: "0" })
+    applyProp(object, "foo", "0")
     expect(object.foo).to.equal(0)
   })
 
@@ -41,7 +41,7 @@ describe("applyProps", () => {
     const object = {
       foo: 0
     }
-    applyProps(object, { foo: "90deg" })
+    applyProp(object, "foo", "90deg")
     expect(object.foo).to.equal(Math.PI / 2)
   })
 
@@ -49,7 +49,7 @@ describe("applyProps", () => {
     const object = {
       foo: new THREE.Vector3()
     }
-    applyProps(object, { foo: "90deg 1.23 -90deg" })
+    applyProp(object, "foo", "90deg 1.23 -90deg")
     expect(object.foo.x).to.equal(Math.PI / 2)
     expect(object.foo.y).to.equal(1.23)
     expect(object.foo.z).to.equal(Math.PI / -2)
@@ -59,7 +59,7 @@ describe("applyProps", () => {
     const object = {
       foo: new THREE.Vector3()
     }
-    applyProps(object, { foo: "[1, 2, 3]" })
+    applyProp(object, "foo", "[1, 2, 3]")
     expect(object.foo.x).to.equal(1)
     expect(object.foo.y).to.equal(2)
     expect(object.foo.z).to.equal(3)

--- a/packages/three-elements/test/util/applyProps.test.ts
+++ b/packages/three-elements/test/util/applyProps.test.ts
@@ -1,4 +1,5 @@
-import { expect, fixture, nextFrame, html } from "@open-wc/testing"
+import { expect, fixture, html } from "@open-wc/testing"
+import sinon from "sinon"
 import * as THREE from "three"
 import "../../src"
 import { ThreeElement, ThreeScene } from "../../src"
@@ -107,9 +108,13 @@ describe("applyPropWithDirective", () => {
 
   describe("with unknown directives", () => {
     it("logs an error message", async () => {
+      const spy = sinon.spy(console, "error")
+
       await renderGame()
       const $scene = document.querySelector("three-scene") as ThreeScene
       applyPropWithDirective($scene, "absolutelyunknown:camera", "#cam")
+
+      expect(spy).to.have.been.calledWith("Unknow directive: absolutelyunknown")
     })
   })
 })

--- a/packages/three-elements/test/util/applyProps.test.ts
+++ b/packages/three-elements/test/util/applyProps.test.ts
@@ -1,6 +1,8 @@
-import { expect } from "@open-wc/testing"
-import { applyProps, applyProp } from "../../src/util/applyProps"
+import { expect, fixture, nextFrame, html } from "@open-wc/testing"
 import * as THREE from "three"
+import "../../src"
+import { ThreeElement, ThreeScene } from "../../src"
+import { applyProp, applyProps, applyPropWithDirective } from "../../src/util/applyProps"
 
 describe("applyProp", () => {
   it("can directly assign root-level properties", () => {
@@ -76,5 +78,38 @@ describe("applyProps", () => {
     applyProps(object, { foo: 1, bar: 2 })
     expect(object.foo).to.equal(1)
     expect(object.bar).to.equal(2)
+  })
+})
+
+describe("applyPropWithDirective", () => {
+  const renderGame = () =>
+    fixture(html`
+      <three-game>
+        <three-scene>
+          <three-perspective-camera id="cam"></three-perspective-camera>
+        </three-scene>
+      </three-game>
+    `)
+
+  describe("with the ref: directive", () => {
+    it("treats the value as a DOM reference", async () => {
+      await renderGame()
+
+      const $scene = document.querySelector("three-scene") as ThreeScene
+      const $camera = document.querySelector("three-perspective-camera") as ThreeElement
+
+      applyPropWithDirective($scene, "ref:camera", "#cam")
+
+      expect($scene.camera).to.be.instanceOf(THREE.PerspectiveCamera)
+      expect($scene.camera).to.eq($camera.object)
+    })
+  })
+
+  describe("with unknown directives", () => {
+    it("logs an error message", async () => {
+      await renderGame()
+      const $scene = document.querySelector("three-scene") as ThreeScene
+      applyPropWithDirective($scene, "absolutelyunknown:camera", "#cam")
+    })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1966,6 +1966,34 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
   integrity sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==
 
+"@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0", "@sinonjs/commons@^1.8.1":
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.2.tgz#858f5c4b48d80778fde4b9d541f27edc0d56488b"
+  integrity sha512-sruwd86RJHdsVf/AtBoijDmUqJp3B6hF/DGC23C+JaegnDHaZyewCjoVGTdg3J0uz3Zs7NnIT05OBOmML72lQw==
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/fake-timers@^6.0.0", "@sinonjs/fake-timers@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz#293674fccb3262ac782c7aadfdeca86b10c75c40"
+  integrity sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==
+  dependencies:
+    "@sinonjs/commons" "^1.7.0"
+
+"@sinonjs/samsam@^5.3.1":
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-5.3.1.tgz#375a45fe6ed4e92fca2fb920e007c48232a6507f"
+  integrity sha512-1Hc0b1TtyfBu8ixF/tpfSHTVWKwCBLY4QJbkgnE7HcwyvT2xArDxb4K7dMgqRm3szI+LJbzmW/s4xxEhv6hwDg==
+  dependencies:
+    "@sinonjs/commons" "^1.6.0"
+    lodash.get "^4.4.2"
+    type-detect "^4.0.8"
+
+"@sinonjs/text-encoding@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
+  integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
+
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-1.1.2.tgz#b1665e2c461a2cd92f4c1bbf50d5454de0d4b421"
@@ -5064,6 +5092,11 @@ diff@3.5.0:
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
 
+diff@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
+
 diff@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-5.0.0.tgz#7ed6ad76d859d030787ec35855f5b1daf31d852b"
@@ -7327,6 +7360,11 @@ is-yarn-global@^0.3.0:
   resolved "https://registry.yarnpkg.com/is-yarn-global/-/is-yarn-global-0.3.0.tgz#d502d3382590ea3004893746754c89139973e232"
   integrity sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==
 
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
+
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -7525,6 +7563,11 @@ jsprim@^1.2.2:
     extsprintf "1.3.0"
     json-schema "0.2.3"
     verror "1.10.0"
+
+just-extend@^4.0.2:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.1.1.tgz#158f1fdb01f128c411dc8b286a7b4837b3545282"
+  integrity sha512-aWgeGFW67BP3e5181Ep1Fv2v8z//iBJfrvyTnq8wG86vEESwmonn1zPBJ0VfmT9CJq2FIT0VsETtrNFm2a+SHA==
 
 keygrip@~1.1.0:
   version "1.1.0"
@@ -8618,6 +8661,17 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
+nise@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-4.0.4.tgz#d73dea3e5731e6561992b8f570be9e363c4512dd"
+  integrity sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==
+  dependencies:
+    "@sinonjs/commons" "^1.7.0"
+    "@sinonjs/fake-timers" "^6.0.0"
+    "@sinonjs/text-encoding" "^0.7.1"
+    just-extend "^4.0.2"
+    path-to-regexp "^1.7.0"
+
 no-case@^2.2.0:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/no-case/-/no-case-2.3.2.tgz#60b813396be39b3f1288a4c1ed5d1e7d28b464ac"
@@ -9356,6 +9410,13 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
+
+path-to-regexp@^1.7.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
+  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
+  dependencies:
+    isarray "0.0.1"
 
 path-type@^1.0.0:
   version "1.1.0"
@@ -11027,6 +11088,18 @@ sinon-chai@^3.3.0:
   resolved "https://registry.yarnpkg.com/sinon-chai/-/sinon-chai-3.5.0.tgz#c9a78304b0e15befe57ef68e8a85a00553f5c60e"
   integrity sha512-IifbusYiQBpUxxFJkR3wTU68xzBN0+bxCScEaKMjBvAQERg6FnTTc1F17rseLb1tjmkJ23730AXpFI0c47FgAg==
 
+sinon@^9.2.4:
+  version "9.2.4"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-9.2.4.tgz#e55af4d3b174a4443a8762fa8421c2976683752b"
+  integrity sha512-zljcULZQsJxVra28qIAL6ow1Z9tpattkCTEJR4RBP3TGc00FcttsP5pK284Nas5WjMZU5Yzy3kAIp3B3KRf5Yg==
+  dependencies:
+    "@sinonjs/commons" "^1.8.1"
+    "@sinonjs/fake-timers" "^6.0.1"
+    "@sinonjs/samsam" "^5.3.1"
+    diff "^4.0.2"
+    nise "^4.0.4"
+    supports-color "^7.1.0"
+
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
@@ -11989,7 +12062,7 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
 
-type-detect@^4.0.0, type-detect@^4.0.5:
+type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5, type-detect@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==


### PR DESCRIPTION
**What's in this PR?**

- Massively reduce the complexity of our `attributeChangedCallback` implementations
- Align attributes and properties; properties on elements can now be exposed as (kebab-cased) attributes, eg. `ThreeScene.backgroundColor` now can be set via `<three-scene background-color="...">`. Properties need to be white-listed via the new `exposedProperties` static property.
- For this to work well, we could no longer assign object instances _or_ DOM CSS selectors to the same attributes/properties. In order to implement element references cleanly, this PR introduces attribute _directives_, eg. `<three-scene ref:camera="#cam">`. This is necessary because some frameworks (like Preact) will automatically assign the attribute value directly to a property of the same name if that property exists, which would require us to perform the resource fetching within each of those properties. Directive solve this in a clean fashion, even if it requires folks to write a few more characters.
- To make the attribute name syntax clearer, nested object attributes can now be set using the dotty syntax only (`position.x="5"`). The colon syntax is no longer supported, since we're now using colons for directives.

**Open questions / to decide / todo:**

- [x] Do we really want to automatically expose all props as attributes? As an alternative (requiring slightly more code, though), we could provide a mechanism to explicitly mark individual properties as also being available as attributes:
  - Pro: it gives you more control over what's exposed and what's not.
  - Pro: it gives us something to hook in to to allow the user to customize the name of the attribute representing the property.
  - Con: lots of extra code that I'm not eager to have.
  - Con: allowing the user to choose an attribute name may actually cause more confusion, namespace collisions, and other edge cases.
  - **Resolution**: I added the `exposedProperties` static property, which acts as a whitelist. applyProps will check the list contained in this property before assigning to a property.
- [x] Is the way we're introducing directives here really the best way?
- [x] Is `ref:...` a good name for a reference directive?
  - I think so! But it largely depends on other directives we may end up adding (if any. Hopefully there will be none none. :b)
  - **Resolution:** I day has passed and I still don't hate it, so yeah, it's good.
- [x] Refactor `applyProp` to make directive support more stable (right now, a "ref" in the middle of a property name chain would be picked up as a directive, woops)
- [x] Change `applyProps` test to test applyProp specifically
  - [ ] Test return booleans
  - [x] Test new directives
- [x] Update Changelog
- [ ] Update Documentation

**COMPLEMENTARY KITTEN:**

![image](https://user-images.githubusercontent.com/1061/107273268-1e679e80-6a4f-11eb-9184-67c990fc106e.png)
